### PR TITLE
Enable dependabot security auto-pr

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) secure and up-to-date,
+  # batching pull requests daily
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"


### PR DESCRIPTION
There has been a security notification about a vulnerability in one of our dependencies since August: https://github.com/bpfkorea/boa-sdk-ts/network/alerts

Trying to see if this can help us stay up to date.

I've used the guide here:

https://dependabot.com/docs/config-file/#dependabot-config-files
https://github.com/dependabot/preview-demo/blob/main/.dependabot/config.yml