### PR TITLE
KeyPair: Remove Seed type, always use SecretKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
 
 export { Hash, hash, hashMulti, makeUTXOKey, hashFull, hashPart } from './modules/common/Hash';
 export { Height } from './modules/common/Height';
-export { KeyPair, PublicKey, SecretKey, Seed } from './modules/common/KeyPair';
+export { KeyPair, PublicKey, SecretKey } from './modules/common/KeyPair';
 export { Signature } from './modules/common/Signature';
 export { Scalar, Point } from './modules/common/ECC';
 export { Sig, Pair, Schnorr, Message } from './modules/common/Schnorr';

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -30,8 +30,7 @@ export class Utils
     public static readonly SIZE_OF_INT: number = 4;
     public static readonly SIZE_OF_LONG: number  = 8;
     public static readonly SIZE_OF_PUBLIC_KEY: number = 32;
-    public static readonly SIZE_OF_SECRET_KEY: number = 64;
-    public static readonly SIZE_OF_SEED_KEY: number = 32;
+    public static readonly SIZE_OF_SECRET_KEY: number = 32;
 
     public static readonly FEE_FACTOR: number = 200;
 

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -61,7 +61,7 @@ let sample_validators =
 /**
  * Sample UTXOs
  */
-let sample_utxo_address = "GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I";
+let sample_utxo_address = "GDA22T4I2OTZTFQBUY36GXJOPREZ5HZFG2RII5ERMUNXZ2NFSZDADLGE";
 let sample_utxo =
     [
         {
@@ -805,7 +805,7 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // Query
-        let public_key = new boasdk.PublicKey("GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I");
+        let public_key = new boasdk.PublicKey("GDA22T4I2OTZTFQBUY36GXJOPREZ5HZFG2RII5ERMUNXZ2NFSZDADLGE");
         let utxos = await boa_client.getUTXOs(public_key);
         assert.strictEqual(utxos.length, sample_utxo.length);
         assert.deepStrictEqual(utxos[0].utxo, new boasdk.Hash(sample_utxo[0].utxo));
@@ -1033,13 +1033,13 @@ describe('BOA Client', () => {
         ];
 
         let keys: Array<boasdk.KeyPair> = [
-            boasdk.KeyPair.fromSeed(new boasdk.Seed("SDAKFNYEIAORZKKCYRILFQKLLOCNPL5SWJ3YY5NM3ZH6GJSZGXHZEPQS")),
-            boasdk.KeyPair.fromSeed(new boasdk.Seed("SAXA7RLGWM5I7Q34WBKXWLDPZ3NHFHATOZG7UUOG5ZGZCM7J64OLTJOT")),
-            boasdk.KeyPair.fromSeed(new boasdk.Seed("SDWAMFTNWY6XLZ2FDGBEMBYIXJTQSSA6OKSPH2YVLZH7NDE3LDFC2AJR"))
+            boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4")),
+            boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SCUCEYS4ZHJ2L6ME4Y37Q77KC3CQE42GLGAV6YDWP5NJVDC53HTQ4IIM")),
+            boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SDZQW3XBFXRXW2L7GVLS7DARGRKPQR5QIB5CDMGQ4KB24T46JURAAOLT"))
         ];
 
         let builder = new boasdk.TxBuilder(
-            boasdk.KeyPair.fromSeed(new boasdk.Seed("SDAKFNYEIAORZKKCYRILFQKLLOCNPL5SWJ3YY5NM3ZH6GJSZGXHZEPQS")));
+            boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4")));
 
         let vote_data = new boasdk.DataPayload("0x617461642065746f76");
         let fee = boasdk.TxPayloadFee.getFee(vote_data.data.length);
@@ -1083,7 +1083,7 @@ describe('BOA Client', () => {
                     "value": "100000",
                     "lock": {
                         "type": 0,
-                        "bytes": "KkpengSTntVIh037afPquSSwuq/KlbhEr/ydUPM4no4="
+                        "bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
                     }
                 },
                 {
@@ -1134,7 +1134,7 @@ describe('BOA Client', () => {
         let fee = boasdk.TxPayloadFee.getFee(vote_data.data.length);
 
         let builder = new boasdk.TxBuilder(
-            boasdk.KeyPair.fromSeed(new boasdk.Seed("SDAKFNYEIAORZKKCYRILFQKLLOCNPL5SWJ3YY5NM3ZH6GJSZGXHZEPQS")));
+            boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4")));
         let tx = builder
             .addInput(utxo.utxo, utxo.amount)
             .addOutput(new boasdk.PublicKey(boasdk.TxPayloadFee.CommonsBudgetAddress), fee)
@@ -1154,7 +1154,7 @@ describe('BOA Client', () => {
         // Create BOA Client
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
-        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.Seed("SBUC7CPSZVNHNNYO3SY7ZNBT3K3X6RWOC3NC4FVU4GOJXC3H5BUBC7YE"));
+        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4"));
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
@@ -1201,7 +1201,7 @@ describe('BOA Client', () => {
                         "value": "100000",
                         "lock": {
                             "type": 0,
-                            "bytes": "2L1pan7b6W/iwgJYgbeuPqYliGn7UoBmGVZkWa6O8U8="
+                            "bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
                         }
                     }
                 ],
@@ -1235,7 +1235,7 @@ describe('BOA Client', () => {
         // Create BOA Client
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
-        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.Seed("SBUC7CPSZVNHNNYO3SY7ZNBT3K3X6RWOC3NC4FVU4GOJXC3H5BUBC7YE"));
+        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4"));
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
@@ -1269,7 +1269,7 @@ describe('BOA Client', () => {
         // Create BOA Client
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
-        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.Seed("SBUC7CPSZVNHNNYO3SY7ZNBT3K3X6RWOC3NC4FVU4GOJXC3H5BUBC7YE"));
+        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4"));
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
@@ -1314,7 +1314,7 @@ describe('BOA Client', () => {
                         "value": "200000",
                         "lock": {
                             "type": 0,
-                            "bytes": "2L1pan7b6W/iwgJYgbeuPqYliGn7UoBmGVZkWa6O8U8="
+                            "bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
                         }
                     }
                 ],
@@ -1373,7 +1373,7 @@ describe('BOA Client', () => {
         // Create BOA Client
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
-        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.Seed("SBUC7CPSZVNHNNYO3SY7ZNBT3K3X6RWOC3NC4FVU4GOJXC3H5BUBC7YE"));
+        let key_pair = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4"));
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
@@ -1498,7 +1498,7 @@ describe('BOA Client', () => {
                     "value": "148000",
                     "lock": {
                         "type": 0,
-                        "bytes": "2L1pan7b6W/iwgJYgbeuPqYliGn7UoBmGVZkWa6O8U8="
+                        "bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
                     }
                 },
                 {

--- a/tests/KeyPair.test.ts
+++ b/tests/KeyPair.test.ts
@@ -16,7 +16,7 @@ import * as boasdk from '../lib';
 import * as assert from 'assert';
 import { base32Encode, base32Decode } from '@ctrl/ts-base32';
 
-describe ('Curve25519 Public Key', () =>
+describe ('Public Key', () =>
 {
     before('Wait for the package libsodium to finish loading', () =>
     {
@@ -45,7 +45,7 @@ describe ('Curve25519 Public Key', () =>
     });
 });
 
-describe ('Curve25519 Secret Key Seed', () =>
+describe ('Secret Key', () =>
 {
     before('Wait for the package libsodium to finish loading', () =>
     {
@@ -54,23 +54,23 @@ describe ('Curve25519 Secret Key Seed', () =>
 
     it ('Extract the seed from a string then convert it back into a string and compare it.', () =>
     {
-        let secret_seed = 'SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ';
-        let seed = new boasdk.Seed(secret_seed);
-        assert.strictEqual(seed.toString(), secret_seed);
+        let secret_str = 'SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ';
+        let secret_key = new boasdk.SecretKey(secret_str);
+        assert.strictEqual(secret_key.toString(false), secret_str);
     });
 
     it ('Test of Seed.validate()', () =>
     {
-        assert.strictEqual(boasdk.Seed.validate("SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7T"), 'Decoded data size is not normal');
-        assert.strictEqual(boasdk.Seed.validate("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"), 'This is not a valid seed type');
-        assert.strictEqual(boasdk.Seed.validate("SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ"), '');
+        assert.strictEqual(boasdk.SecretKey.validate("SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7T"), 'Decoded data size is not normal');
+        assert.strictEqual(boasdk.SecretKey.validate("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"), 'This is not a valid seed type');
+        assert.strictEqual(boasdk.SecretKey.validate("SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ"), '');
 
         const decoded = Buffer.from(base32Decode("SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ"));
         const body = decoded.slice(0, -2);
         const checksum = decoded.slice(-2);
         let invalid_decoded = Buffer.concat([body, checksum.map(n => ~n)]);
         let invalid_seed = base32Encode(invalid_decoded);
-        assert.strictEqual(boasdk.Seed.validate(invalid_seed), 'Checksum result do not match');
+        assert.strictEqual(boasdk.SecretKey.validate(invalid_seed), 'Checksum result do not match');
     });
 });
 
@@ -81,13 +81,13 @@ describe ('KeyPair', () =>
         return boasdk.SodiumHelper.init();
     });
 
-    // See: https://github.com/bosagora/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/crypto/Key.d#L375-L386
+    // See: https://github.com/bosagora/agora/blob/bcd14f2c6a3616d7f05ef850dc95fae3eb386760/source/agora/crypto/Key.d#L391-L404
     it ('Test of KeyPair.fromSeed, sign, verify', () =>
     {
-        let address = `GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW`;
-        let seed = `SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ`;
+        let address = `GDNODE2JBW65U6WVIOESR3OTJUFOHPHTEIL4GQINDB3MVB645KXAHG73`;
+        let seed = `SDV3GLVZ6W7R7UFB2EMMY4BBFJWNCQB5FTCXUMD5ZCFTDEVZZ3RQ2BZI`;
 
-        let kp = boasdk.KeyPair.fromSeed(new boasdk.Seed(seed));
+        let kp = boasdk.KeyPair.fromSeed(new boasdk.SecretKey(seed));
         assert.strictEqual(kp.address.toString(), address);
 
         let signature = kp.secret.sign(Buffer.from('Hello World'));
@@ -102,7 +102,7 @@ describe ('KeyPair', () =>
         assert.ok(random_kp.address.verify(random_kp_signature, Buffer.from('Hello World')));
 
         // Test whether randomly generated key-pair are reproducible.
-        let reproduced_kp = boasdk.KeyPair.fromSeed(random_kp.seed);
+        let reproduced_kp = boasdk.KeyPair.fromSeed(random_kp.secret);
 
         let reproduced_kp_signature = reproduced_kp.secret.sign(Buffer.from('Hello World'));
         assert.ok(reproduced_kp.address.verify(reproduced_kp_signature, Buffer.from('Hello World')));

--- a/tests/Schnorr.test.ts
+++ b/tests/Schnorr.test.ts
@@ -254,9 +254,9 @@ describe ('Test of Schnorr', () =>
 
     it ('Test signing using Stellar seed', () =>
     {
-        let seed = `SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4`;
-        let kp: sdk.KeyPair = sdk.KeyPair.fromSeed(new sdk.Seed(seed));
-        assert.deepStrictEqual(kp.secret.scalar, new sdk.Scalar("0x44245dd23bd7453bf5fe07ec27a29be3dfe8e18d35bba28c7b222b71a4802db8"));
+        let seed = `SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4`;
+        let kp: sdk.KeyPair = sdk.KeyPair.fromSeed(new sdk.SecretKey(seed));
+        assert.deepStrictEqual(kp.secret.scalar, new sdk.Scalar("0x080267e00c79b9ca75b646df38c2a739c36158eacfc6980b78adb3353e5d82f8"));
 
         let pair: sdk.Pair = sdk.Pair.fromScalar(kp.secret.scalar);
         assert.deepStrictEqual(pair.V.data, kp.address.data);

--- a/tests/TxBuilder.test.ts
+++ b/tests/TxBuilder.test.ts
@@ -37,7 +37,7 @@ describe ('TxBuilder', () =>
             utxo: new boasdk.Hash('0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef'),
             amount: JSBI.BigInt(1000000000)
         }
-        owner = boasdk.KeyPair.fromSeed(new boasdk.Seed("SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ"))
+        owner = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4"))
     });
 
     it ('When trying to send the wrong amount', () =>
@@ -102,7 +102,7 @@ describe ('TxBuilder', () =>
                     "value": "1980000000",
                     "lock": {
                         "type": 0,
-                        "bytes": "x9iUwUUAUTrwBrnguo84lfyvTZHHT46ge180pVV6WNU="
+                        "bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
                     }
                 },
                 {
@@ -170,7 +170,7 @@ describe ('TxBuilder', () =>
                     "value": "1999500000",
                     "lock": {
                         "type": 0,
-                        "bytes": "x9iUwUUAUTrwBrnguo84lfyvTZHHT46ge180pVV6WNU="
+                        "bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
                     }
                 }
             ],

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -91,9 +91,8 @@ describe ('Test of Utils', () =>
 
     it ('Test of sizeof keys', () =>
     {
-        assert.strictEqual(boasdk.Utils.SIZE_OF_PUBLIC_KEY, boasdk.SodiumHelper.sodium.crypto_sign_PUBLICKEYBYTES);
-        assert.strictEqual(boasdk.Utils.SIZE_OF_SECRET_KEY, boasdk.SodiumHelper.sodium.crypto_sign_SECRETKEYBYTES);
-        assert.strictEqual(boasdk.Utils.SIZE_OF_SEED_KEY, boasdk.SodiumHelper.sodium.crypto_sign_SEEDBYTES);
+        assert.strictEqual(boasdk.Utils.SIZE_OF_PUBLIC_KEY, boasdk.SodiumHelper.sodium.crypto_core_ed25519_BYTES);
+        assert.strictEqual(boasdk.Utils.SIZE_OF_SECRET_KEY, boasdk.SodiumHelper.sodium.crypto_core_ed25519_SCALARBYTES);
     });
 
     it ('Test of BitField JSON serialization', () =>

--- a/tests/Vote.test.ts
+++ b/tests/Vote.test.ts
@@ -60,10 +60,10 @@ describe ('Vote Data', () =>
     it ('Test of Vote', () =>
     {
         // The seed key of the validator
-        let seed = `SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ`;
+        let seed = `SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4`;
 
         // The KeyPair of the validator
-        let validator_key = boasdk.KeyPair.fromSeed(new boasdk.Seed(seed));
+        let validator_key = boasdk.KeyPair.fromSeed(new boasdk.SecretKey(seed));
 
         // The temporary KeyPair
         let temporary_key = boasdk.KeyPair.random();
@@ -121,10 +121,10 @@ describe ('Vote Data', () =>
     it ('The size of BallotData', () =>
     {
         // The seed key of the validator
-        let seed = `SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ`;
+        let seed = `SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4`;
 
         // The KeyPair of the validator
-        let validator_key = boasdk.KeyPair.fromSeed(new boasdk.Seed(seed));
+        let validator_key = boasdk.KeyPair.fromSeed(new boasdk.SecretKey(seed));
         // The temporary KeyPair
         let temporary_key = boasdk.KeyPair.random();
         let voter_card = new boasdk.VoterCard(validator_key.address, temporary_key.address, JSBI.BigInt(Date.now().valueOf()));
@@ -211,10 +211,10 @@ describe ('Vote Data', () =>
     it ('Test link data of Vote', () =>
     {
         // The KeyPair of the validator
-        let validator_key = boasdk.KeyPair.fromSeed(new boasdk.Seed("SBBUWIMSX5VL4KVFKY44GF6Q6R5LS2Z5B7CTAZBNCNPLS4UKFVDXC7TQ"));
+        let validator_key = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SDZQW3XBFXRXW2L7GVLS7DARGRKPQR5QIB5CDMGQ4KB24T46JURAAOLT"));
 
         // The temporary KeyPair
-        let temporary_key = boasdk.KeyPair.fromSeed(new boasdk.Seed("SDVK3TKVJLE324I5JYKZK62YU6ADXKCLKDKTHRJIED5FL32WMAFDPDXZ"));
+        let temporary_key = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SANGEY2BIMFZ3K3T3NWSVYBS65N55SZE7WBEVVXQFLLZI6GLZBKACO6G"));
 
         let voter_card = new boasdk.VoterCard(validator_key.address, temporary_key.address, boasdk.JSBI.BigInt(10000000));
         let voter_card_hash = boasdk.hashFull(voter_card);
@@ -231,7 +231,7 @@ describe ('Vote Data', () =>
 
         let link_data = ballot_data.getLinkData();
         let expected = {
-            payload: 'CEJBTExPVCAgDElEMTIzNDU2Nzg5MCnrh2CqgtLfg5AHdxBVuZMzSeM18Ym5b/NTj1wn7D77DX6nQauhGnpQ+MfYlMFFAFE68Aa54LqPOJX8r02Rx0+OoHtfNKVVeljV3601ecRvqYXBtM3PYEcP7V/5PfTYPLuzHSD0L+0TOQ/+gJaYADctGQG0YgE1vUjOIy36U7S+f/YJfiQ3csek6FCZ03jE2pHlGLmyaNlyvaH+W1LLYN0JmTovL1wJ2dSuDdb07AxkxQw6J3MFkkTwHuBwJV6i8cXcstC4gYdXkRwZa93JPW+LFxRZ++JPFx/ecghOd4Oxdg9eGfrREDc5m6dZ1JL/Bw=='
+            payload: 'CEJBTExPVCAgDElEMTIzNDU2Nzg5MCkOBl0aicgLwMN9EnvkTlm/n9reo1cC9ALJjL8hwMZo+0ZIs7VLqrqgwMWtIp2TBufIJIhInD6XvqjImZjxWdzHSZiNYVXVuKDmx60Co13nUDL3h+pKXCsG460FHRgDZWnJFfTYnch/tLj+gJaYAHe47it2ufN/ZpM/06sDLIv5OdpdlxIi8XIfJdWEenBLRI7A6tBYX9h+9jx1KXmPoEE2OfnC8+JOuTCvxrXZrwJkiPjaBEYGCGIoQ1GDr0M8J8BdnRPxXCIMvw7L422+eaCn0HuVWrMySyf93G7fWlU+DiHdJzuyVm9P+zAvJVQQAg=='
         };
 
         let deserialized_ballot_data = boasdk.BallotData.deserialize(SmartBuffer.fromBuffer(Buffer.from(link_data.payload, "base64")));


### PR DESCRIPTION
I adapt the recently changed class `KeyPair` to SDK.


Related to https://github.com/bosagora/agora/pull/1786

