### PR TITLE
Switch address format from Stellar-style to bech32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,15 @@
       "resolved": "https://registry.npmjs.org/@ctrl/ts-base32/-/ts-base32-1.2.4.tgz",
       "integrity": "sha512-hqFDbgdcvMVF0RA7T6TTZNy7Nv3YXKuv8hHxBoejc+L1FHdTUMqK2GNyr228tsPUPnMaRrekfI8+u9yxYu6L6g=="
     },
+    "@types/bech32": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/bech32/-/bech32-1.1.2.tgz",
+      "integrity": "sha512-D2tG6kfIcZD3pjtnnvGrwiZiz+HGBsoy0pdGlpBeMbhlKJ4l4r1zB8SEQPL790kTdSS8lhyC/w9API7L2YBOxw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -557,6 +566,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "big.js": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@ctrl/ts-base32": "^1.2.1",
     "ajv": "^6.12.6",
     "axios": "^0.21.1",
+    "bech32": "^2.0.0",
     "crc": "^3.8.0",
     "jsbi": "^3.1.4",
     "libsodium-wrappers-sumo": "^0.7.9",
@@ -38,6 +39,7 @@
     "urijs": "^1.19.2"
   },
   "devDependencies": {
+    "@types/bech32": "^1.1.2",
     "@types/chai": "^4.2.11",
     "@types/crc": "^3.4.0",
     "@types/express": "^4.17.6",

--- a/src/modules/utils/TxPayloadFee.ts
+++ b/src/modules/utils/TxPayloadFee.ts
@@ -22,7 +22,7 @@ export class TxPayloadFee
      * The address of commons budget
      */
     public static CommonsBudgetAddress: string
-        = "GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU";
+        = "boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s";
 
     /**
      * The maximum size of data payload

--- a/src/modules/utils/Utils.ts
+++ b/src/modules/utils/Utils.ts
@@ -254,4 +254,43 @@ export class Utils
 
         return a.length - b.length;
     }
+
+    /**
+     * Convert from one power-of-2 number base to another
+     * @param out_values  The values that has converted
+     * @param in_values   The values to be converted
+     * @param from        A power-of-2 number base of `in_values`
+     * @param to          A power-of-2 number base of `out_values`
+     * @param pad         Check if the pads are added
+     * @returns true if the conversion succeeds
+     */
+    public static convertBits (out_values: Array<number>, in_values: Array<number>, from: number, to: number, pad: boolean): boolean
+    {
+        let acc: number = 0;
+        let bits: number = 0;
+        const max_v: number = (1 << to) - 1;
+        const max_acc: number = (1 << (from + to - 1)) - 1;
+
+        for (let i = 0; i < in_values.length; ++i)
+        {
+            let value = in_values[i];
+            acc = ((acc << from) | value) & max_acc;
+            bits += from;
+            while (bits >= to)
+            {
+                bits -= to;
+                out_values.push(((acc >> bits) & max_v) & 0xff);
+            }
+        }
+        if (pad)
+        {
+            if (bits !== 0)
+                out_values.push(((acc << (to - bits)) & max_v) & 0xff);
+        }
+        else if (bits >= from || ((acc << (to - bits)) & max_v))
+        {
+            return false;
+        }
+        return true;
+    }
 }

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -27,7 +27,7 @@ import URI from 'urijs';
 let sample_validators =
     [
         {
-            "address": "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN",
+            "address": "boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0",
             "enrolled_at": 0,
             "stake": "0x210b66053c73e7bd7b27673706f0272617d09b8cda76605e91ab66ad1cc3bfc1f3f5fede91fd74bb2d2073de587c6ee495cfb0d981f03a83651b48ce0e576a1a",
             "preimage":
@@ -37,7 +37,7 @@ let sample_validators =
                 }
         },
         {
-            "address": "GBUVRIIBMHKC4PE6BK7MO2O26U2NJLW4WGGWKLAVLAA2DLFZTBHHKOEK",
+            "address": "boa1xrp66va5qe84kyfhywhxz9luy7glpxu99n30cuv3mu0vkhcswuzajgak3pw",
             "enrolled_at": 0,
             "stake": "0x86f1a6dff3b1f2256d2417b71ecc5511293b224894da5fd75c192965aa1874824ca777ecac678c871e717ad38c295046f4f64130f31750aa967c30c35529944a",
             "preimage":
@@ -47,7 +47,7 @@ let sample_validators =
                 }
         },
         {
-            "address": "GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ",
+            "address": "boa1xrz66g5ajvrw0jpy3pyfc05hh65v3xvc79vae36fnzxkz4w4hzswv90ypcp",
             "enrolled_at": 0,
             "stake": "0xf21f606e96d6130b02a807655fda22c8888111f2045c0d45eda9c26d3c97741ca32fc68960ae68220809843d92671083e32395a848203380e5dfd46e4b0261f0",
             "preimage":
@@ -61,7 +61,7 @@ let sample_validators =
 /**
  * Sample UTXOs
  */
-let sample_utxo_address = "GDA22T4I2OTZTFQBUY36GXJOPREZ5HZFG2RII5ERMUNXZ2NFSZDADLGE";
+let sample_utxo_address = "boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0";
 let sample_utxo =
     [
         {
@@ -204,8 +204,8 @@ let sample_txs_history =
     [
         {
             display_tx_type: 'inbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '9',
             time: 1601553600,
@@ -217,8 +217,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'outbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '8',
             time: 1600953600,
@@ -230,8 +230,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'inbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '7',
             time: 1600353600,
@@ -243,8 +243,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'outbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '6',
             time: 1599753600,
@@ -256,8 +256,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'inbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '5',
             time: 1599153600,
@@ -269,8 +269,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'outbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '4',
             time: 1598553600,
@@ -282,8 +282,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'inbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '3',
             time: 1597953600,
@@ -295,8 +295,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'outbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '2',
             time: 1597353600,
@@ -308,8 +308,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'inbound',
-            address: 'GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD',
-            peer: 'GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ',
+            address: 'boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9',
+            peer: 'GDAZW22V4WVQ6Y6ILIKY3BNODEWBXXK5VY2B3HACFM6VWV4JEEAPDHCC',
             peer_count: 1,
             height: '1',
             time: 1596753600,
@@ -332,14 +332,14 @@ let sample_tx_overview =
         payload: '',
         senders: [
             {
-                address: 'GDI22L72RGWY3BEFK2VUBWMJMSZU5SQNCQLN5FCF467RFIYN5KMY3YJT',
+                address: 'boa1xrgq6607dulyra5r9dw0ha6883va0jghdzk67er49h3ysm7k222ruhh7400',
                 amount: 610000000000000,
                 utxo: '0xb0383981111438cf154c7725293009d53462c66d641f76506400f64f55f9cb2e253dafb37af9fafd8b0031e6b9789f96a3a4be06b3a15fa592828ec7f8c489cc'
             }
         ],
         receivers: [
             {
-                address: 'GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI',
+                address: 'boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0',
                 amount: 610000000000000,
                 utxo: '0xefed6c1701d1195524d469a3bbb058492a7922ff98e7284a01f14c0a32c31814f4ed0d6666aaf7071ae0f1eb615920173f13a63c8774aa5955a3af77c51e55e9'
             }
@@ -352,14 +352,14 @@ let sample_txs_pending =
         {
             tx_hash: '0xcf8e55b51027342537ebbdfc503146033fcd8091054913e78d6a858125f892a24b0734afce7154fdde85688ab1700307b999b2e5a17a724990bb83d3785e89da',
             submission_time: 1613404086,
-            address: 'GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU',
+            address: 'boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s',
             amount: '1663400000',
             fee: '0'
         },
         {
             tx_hash: '0xcf8e55b51027342537ebbdfc503146033fcd8091054913e78d6a858125f892a24b0734afce7154fdde85688ab1700307b999b2e5a17a724990bb83d3785e89da',
             submission_time: 1613404086,
-            address: 'GDID227ETHPOMLRLIHVDJSNSJVLDS4D4ANYOUHXPMG2WWEZN5JO473ZO',
+            address: 'boa1xrgr66gdm5je646x70l5ar6qkhun0hg3yy2eh7tf8xxlmlt9fgjd2q0uj8p',
             amount: '24398336600000',
             fee: '0'
         }
@@ -754,12 +754,12 @@ describe('BOA Client', () => {
         let stoa_uri = URI("http://localhost")
             .port(stoa_port)
             .directory("validator")
-            .filename("GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ")
+            .filename("boa1xrp66va5qe84kyfhywhxz9luy7glpxu99n30cuv3mu0vkhcswuzajgak3pw")
             .setSearch("height", "10");
 
         let response = await client.get (stoa_uri.toString());
         assert.strictEqual(response.data.length, 1);
-        assert.strictEqual(response.data[0].address, "GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ");
+        assert.strictEqual(response.data[0].address, "boa1xrp66va5qe84kyfhywhxz9luy7glpxu99n30cuv3mu0vkhcswuzajgak3pw");
         assert.strictEqual(response.data[0].preimage.distance, 10);
     });
 
@@ -775,7 +775,7 @@ describe('BOA Client', () => {
         // Query
         let validators = await boa_client.getAllValidators(10);
         assert.strictEqual(validators.length, 3);
-        assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+        assert.strictEqual(validators[0].address, "boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0");
         assert.strictEqual(validators[0].preimage.distance, 10);
     });
 
@@ -789,9 +789,9 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // Query
-        let validators = await boa_client.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10);
+        let validators = await boa_client.getValidator("boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0", 10);
         assert.strictEqual(validators.length, 1);
-        assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+        assert.strictEqual(validators[0].address, "boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0");
         assert.strictEqual(validators[0].preimage.distance, 10);
     });
 
@@ -805,7 +805,7 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // Query
-        let public_key = new boasdk.PublicKey("GDA22T4I2OTZTFQBUY36GXJOPREZ5HZFG2RII5ERMUNXZ2NFSZDADLGE");
+        let public_key = new boasdk.PublicKey("boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0");
         let utxos = await boa_client.getUTXOs(public_key);
         assert.strictEqual(utxos.length, sample_utxo.length);
         assert.deepStrictEqual(utxos[0].utxo, new boasdk.Hash(sample_utxo[0].utxo));
@@ -839,7 +839,7 @@ describe('BOA Client', () => {
         // Query
         let validators = await boa_client.getAllValidators(10);
         assert.strictEqual(validators.length, 3);
-        assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+        assert.strictEqual(validators[0].address, "boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0");
         assert.strictEqual(validators[0].preimage.distance, 10);
     });
 
@@ -852,9 +852,9 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // Query
-        let validators = await boa_client.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10);
+        let validators = await boa_client.getValidator("boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0", 10);
         assert.strictEqual(validators.length, 1);
-        assert.strictEqual(validators[0].address, "GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN");
+        assert.strictEqual(validators[0].address, "boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0");
         assert.strictEqual(validators[0].preimage.distance, 10);
     });
 
@@ -868,7 +868,7 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // Query
-        let validators = await boa_client.getValidator("GX3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10);
+        let validators = await boa_client.getValidator("boa1xrr66q4rthn4qvhhsl4y5hptqm366pgarqpk26wfzh6d38wg076tsqqesgg", 10);
         assert.strictEqual(validators.length, 0);
     });
 
@@ -882,7 +882,7 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         await assert.rejects(
-            boa_client.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", -10),
+            boa_client.getValidator("boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0", -10),
             {
                 status: 400,
                 message: "Bad Request",
@@ -900,7 +900,7 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         await assert.rejects(
-            boa_client.getValidator("GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN", 10),
+            boa_client.getValidator("boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0", 10),
             {
                 message: "connect ECONNREFUSED 127.0.0.1:6000"
             });
@@ -1059,21 +1059,21 @@ describe('BOA Client', () => {
                 {
                     "utxo": "0x81a326afa790003c32517a2a2556613004e6147edac28d576cf7bcc2daadf4bb60be1f644c229b775e7894844ec66b2d70ddf407b8196b46bc1dfe42061c7497",
                     "unlock": {
-                        "bytes": "uefV85aW9nVp6Nyv4F7yri41Mp6Xer278npElumnXf7EUFM3CxaOuX1xYI3PxMuKYlGGB8C6hZ9LBpXCT+5CDQ=="
+                        "bytes": "9vSzHA03/64wlGV2zT8S6iMXFFkpwPlWWTVOHQc6D2AfexfD1RxS/VdFQ8qpTSsxxttV/EZVKtigZ7K2kRUIBg=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a",
                     "unlock": {
-                        "bytes": "YZvabkT4c29FIBa/kH/VfYbUxIe1RY33Fy8DA1zb7n1LH3MDW2Bnu+NAZBwTTx5KKshoTL+lJTjq0SefDWosBA=="
+                        "bytes": "Kwz0wvnqqJX5zwvqpKnFF+76DiUVyNDYqDUm6LjhyIFJN8x1h4l5sBHns7aNX1NoH3A80xJ+xme77Mh31371CQ=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0x4028965b7408566a66e4cf8c603a1cdebc7659a3e693d36d2fdcb39b196da967914f40ef4966d5b4b1f4b3aae00fbd68ffe8808b070464c2a101d44f4d7b0170",
                     "unlock": {
-                        "bytes": "KVk9MvR9vWDB5BMY8SKmb4WvNh3vm9Jh4NgRs0W8wWVoaAygGlz/gHE3kbnb6uuly2WZkXmj36j/BZtoVQY/Bg=="
+                        "bytes": "HYBT2ksTcfoWSyGGdmgqSy2ZkEsh7hBtbXQG7QdD0beYZHtQ0khm2nauZN916KkIspWl6v5mNZqg8zvhFJVyCw=="
                     },
                     "unlock_age": 0
                 }
@@ -1090,7 +1090,7 @@ describe('BOA Client', () => {
                     "value": "500000",
                     "lock": {
                         "type": 0,
-                        "bytes": "nMY5oTUvd/IlFgxC/4kaavpbRqEaaalJIIbXeAZ29Co="
+                        "bytes": "xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM="
                     }
                 }
             ],
@@ -1385,7 +1385,7 @@ describe('BOA Client', () => {
         // Create UTXOManager
         let utxo_manager = new boasdk.UTXOManager(utxos);
 
-        let output_address = "GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW";
+        let output_address = "boa1xrr66q4rthn4qvhhsl4y5hptqm366pgarqpk26wfzh6d38wg076tsqqesgg";
         let output_count = 2;
         let estimated_tx_fee = JSBI.BigInt(boasdk.Utils.FEE_FACTOR *
             boasdk.Transaction.getEstimatedNumberOfBytes(0, output_count, vote_data.data.length));
@@ -1460,35 +1460,35 @@ describe('BOA Client', () => {
                 {
                     "utxo": "0x3451d94322524e3923fd26f0597fb8a9cdbf3a9427c38ed1ca61104796d39c5b9b5ea33d576f17c2dc17bebc5d84a0559de8c8c521dfe725d4c352255fc71e85",
                     "unlock": {
-                        "bytes": "DNHSZrt2MV2iFPVZNBsEjmpUopyZYgM9xcrA6DMaQG2nMZSiAhp31xCfLjkG6SjAVbHtVkMAeBnIc0ywy0tYAQ=="
+                        "bytes": "4qgxRsfgLCaBKDVw9KJM/BfKb8tJX41s8WgxcNCAUq83APZtIxyVYs2Te//osUEAFhcpTSagF1zglG/myF4+Bg=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0xfca92fe76629311c6208a49e89cb26f5260777278cd8b272e7bb3021adf429957fd6844eb3b8ff64a1f6074126163fd636877fa92a1f4329c5116873161fbaf8",
                     "unlock": {
-                        "bytes": "DNHSZrt2MV2iFPVZNBsEjmpUopyZYgM9xcrA6DMaQG2nMZSiAhp31xCfLjkG6SjAVbHtVkMAeBnIc0ywy0tYAQ=="
+                        "bytes": "mqMB1bLL0PXTEB80TuMh5mBPllHNW/EF1EkAyE8lQbIOFhr44s3wCpS5unUdDPeDgZoMOzuqFc7S7OTkG/hUDg=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0x7e1958dbe6839d8520d65013bbc85d36d47a9f64cf608cc66c0d816f0b45f5c8a85a8990725ffbb1ab13c3c65b45fdc06f4745d455e00e1068c4c5c0b661d685",
                     "unlock": {
-                        "bytes": "DNHSZrt2MV2iFPVZNBsEjmpUopyZYgM9xcrA6DMaQG2nMZSiAhp31xCfLjkG6SjAVbHtVkMAeBnIc0ywy0tYAQ=="
+                        "bytes": "0hwN3QwAtBXXNrd6YwP5CNLZcKsr+1SkARXwqNCiHeBgRqzELLoVpOEVuTGfEh7fmnsb8zUc2qfSybH75T78Cg=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0xd44608de8a5015b04f933098fd7f67f84ffbf00c678836d38c661ab6dc1f149606bdc96bad149375e16dc5722b077b14c0a4afdbe6d30932f783650f435bcb92",
                     "unlock": {
-                        "bytes": "DNHSZrt2MV2iFPVZNBsEjmpUopyZYgM9xcrA6DMaQG2nMZSiAhp31xCfLjkG6SjAVbHtVkMAeBnIc0ywy0tYAQ=="
+                        "bytes": "61WpwyBIJeYArr26pv2S1QhxTiraQwvt+Gn9xWFhge11uZ2tQYu3eiw8UZ4KRKmQGlymRqfpY+bKwIJDJKVQDQ=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0xc3780f9907a97c20a2955945544e7732a60702c32d81e016bdf1ea172b7b7fb96e9a4164176663a146615307aaadfbbad77e615a7c792a89191e85471120d314",
                     "unlock": {
-                        "bytes": "DNHSZrt2MV2iFPVZNBsEjmpUopyZYgM9xcrA6DMaQG2nMZSiAhp31xCfLjkG6SjAVbHtVkMAeBnIc0ywy0tYAQ=="
+                        "bytes": "csSLViq4Dz7pc01erw3vkBHQObfJSiFtxSBgoAiitHy31NrZaeArFYEZle7oDDvH8J+RrRXgI4bKRSRap5axCQ=="
                     },
                     "unlock_age": 0
                 }
@@ -1505,7 +1505,7 @@ describe('BOA Client', () => {
                     "value": "200000",
                     "lock": {
                         "type": 0,
-                        "bytes": "x9iUwUUAUTrwBrnguo84lfyvTZHHT46ge180pVV6WNU="
+                        "bytes": "x60Co13nUDL3h+pKXCsG460FHRgDZWnJFfTYnch/tLg="
                     }
                 }
             ],
@@ -1532,7 +1532,7 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // Query
-        let public_key = new boasdk.PublicKey("GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I");
+        let public_key = new boasdk.PublicKey("boa1xrx66ezhd6uzx2s0plpgtwwmwmv4tfzvgp5sswqcg8z6m79s05pactt2yc9");
         let data = await boa_client.getWalletTransactionsHistory(public_key, 10, 1, ["payment", "freeze"]);
         assert.deepStrictEqual(data, sample_txs_history);
     });
@@ -1562,7 +1562,7 @@ describe('BOA Client', () => {
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // Query
-        let public_key = new boasdk.PublicKey("GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I");
+        let public_key = new boasdk.PublicKey("boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s");
         let data = await boa_client.getWalletTransactionsPending(public_key);
         assert.deepStrictEqual(data, sample_txs_pending);
     });

--- a/tests/Hash.test.ts
+++ b/tests/Hash.test.ts
@@ -124,7 +124,7 @@ describe('Hash', () =>
     // See_Also: https://github.com/bosagora/agora/blob/73a7cd593afab6726021e05cf16b90d246343d65/source/agora/consensus/data/Block.d#L118-L138
     it ('Test for hash value of BlockHeader', () =>
     {
-        let pubkey = new boasdk.PublicKey('GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW');
+        let pubkey = new boasdk.PublicKey('boa1xrr66q4rthn4qvhhsl4y5hptqm366pgarqpk26wfzh6d38wg076tsqqesgg');
 
         let tx = new boasdk.Transaction(
             boasdk.TxType.Payment,
@@ -145,13 +145,13 @@ describe('Hash', () =>
             0
         );
         assert.strictEqual(boasdk.hashFull(header).toString(),
-            "0xf9970c8b9f45c172c21df299db3c1db6ac3e618629e3229eb8650921e52fc00" +
-            "80417a93714fc15a01d6bbf91004e0646c7377c2608c34d272a2b0a5897fced4f");
+            "0xae5eb320aec482edb3fa2ab8eb3c7577f9fe10beaba95eb46e72b39b4053b79" +
+            "74da42afeb1d34439c7a57b5b3dc6df4d46f72870138636decd5e60b367612138");
     });
 
     it ('Test for hash value of BlockHeader with missing validators', () =>
     {
-        let pubkey = new boasdk.PublicKey('GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW');
+        let pubkey = new boasdk.PublicKey('boa1xrr66q4rthn4qvhhsl4y5hptqm366pgarqpk26wfzh6d38wg076tsqqesgg');
 
         let tx = new boasdk.Transaction(
             boasdk.TxType.Payment,
@@ -172,7 +172,7 @@ describe('Hash', () =>
             0
         );
         assert.strictEqual(boasdk.hashFull(header).toString(),
-            "0xab369553e5871c2e180fa2ab8162f74e552266baa71efc2445fc208048f2824" +
-            "99106f0ba280e3c83a13dab79b7f91be72973ca1e23c56b094ed02a182ef53956");
+            "0x252c0ef24da4ba4d4302b8b14eadfb8a4ba87862ff75acd8a7c801e3c55dbb8" +
+            "6307f5208ceb2b8095630cfb5d9e28dbc709824df85bed906a05a1005a076c672");
     });
 });

--- a/tests/KeyPair.test.ts
+++ b/tests/KeyPair.test.ts
@@ -15,6 +15,7 @@ import * as boasdk from '../lib';
 
 import * as assert from 'assert';
 import { base32Encode, base32Decode } from '@ctrl/ts-base32';
+import { bech32, bech32m } from 'bech32';
 
 describe ('Public Key', () =>
 {
@@ -23,25 +24,152 @@ describe ('Public Key', () =>
         return boasdk.SodiumHelper.init();
     });
 
+    it ('Test Bech32', () =>
+    {
+        let addresses_bech32 = [
+            // CoinNet Genesis Address
+            // GDGENYO6TWO6EZG2OXEBVDCNKLHCV2UFLLZY6TJMWTGR23UMJHVHLHKJ
+            {
+                address: "boa1xrxydcw7nkw7yex6whyp4rzd2t8z4659ttec7nfvknx36m5vf8482zsr6r4",
+                bytes: [
+                    204, 70, 225, 222, 157, 157, 226, 100,
+                    218, 117, 200, 26, 140, 77, 82, 206,
+                    42, 234, 133, 90, 243, 143, 77, 44,
+                    180, 205, 29, 110, 140, 73, 234, 117]
+            },
+            // CoinNet CommonsBudget Address
+            // GCOMBBXA6ON7PT7APS4IWS4N53FCBQTLWBPIU4JR2DSOBCA72WEB4XU4
+            {
+                address: "boa1xzwvpphq7wdl0nlq0jugkjudam9zpsntkp0g5uf36rjwpzql6kypuc3gffp",
+                bytes: [
+                    156, 192, 134, 224, 243, 155, 247, 207,
+                    224, 124, 184, 139, 75, 141, 238, 202,
+                    32, 194, 107, 176, 94, 138, 113, 49,
+                    208, 228, 224, 136, 31, 213, 136, 30]
+            },
+            // TestNet Genesis Address
+            // GDGENES4KXH7RQJELTONR7HSVISVSQ5POSVBEWLR6EEIIL72H24IEDT4
+            {
+                address: "boa1xrxydyju2h8l3sfytnwd3l8j4gj4jsa0wj4pykt37yyggtl686ugypjzxpf",
+                bytes: [
+                    204, 70, 146, 92, 85, 207, 248, 193,
+                        36, 92, 220, 216, 252, 242, 170, 37,
+                        89, 67, 175, 116, 170, 18, 89, 113,
+                        241, 8, 132, 47, 250, 62, 184, 130]
+            },
+            // TestNet CommonsBudget Address
+            // GDCOMMO272NFWHV5TQAIQFEDLQZLBMVVOJTHC3F567ZX4ZSRQQQWGLI3
+            {
+                address: "boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskx7thkmj",
+                bytes: [
+                    196, 230, 49, 218, 254, 154, 91, 30,
+                    189, 156, 0, 136, 20, 131, 92, 50,
+                    176, 178, 181, 114, 102, 113, 108, 189,
+                    247, 243, 126, 102, 81, 132, 33, 99]
+            },
+            // Null Address
+            {
+                address: "boa1xqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgezvze",
+                bytes: [
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0]
+            },
+            // GDNODE2JBW65U6WVIOESR3OTJUFOHPHTEIL4GQINDB3MVB645KXAHG73
+            {
+                address: "boa1xrdwry6fpk7a57k4gwyj3mwnf59w808nygtuxsgdrpmv4p7ua2hqxtmjcu3",
+                bytes: [
+                    218, 225, 147, 73, 13, 189, 218, 122,
+                        213, 67, 137, 40, 237, 211, 77, 10,
+                        227, 188, 243, 34, 23, 195, 65, 13,
+                        24, 118, 202, 135, 220, 234, 174, 3]
+            },
+            // GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW
+            {
+                address: "boa1xrra39xpg5q9zwhsq6u7pw508z2let6dj8r5lr4q0d0nff240fvd2tct454",
+                bytes: [
+                    199, 216, 148, 193, 69, 0, 81, 58,
+                    240, 6, 185, 224, 186, 143, 56, 149,
+                    252, 175, 77, 145, 199, 79, 142, 160,
+                    123, 95, 52, 165, 85, 122, 88, 213]
+            },
+            // GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+            {
+                address: "boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecssz9deump",
+                bytes: [
+                    74, 53, 154, 16, 24, 201, 161, 3,
+                    21, 34, 234, 251, 210, 241, 239, 245,
+                    153, 244, 142, 155, 12, 152, 5, 243,
+                    65, 228, 183, 145, 196, 206, 33, 1]
+            },
+            // GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+            {
+                address: "boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gs9f3rtg",
+                bytes: [
+                    112, 174, 35, 127, 102, 84, 181, 240,
+                    26, 132, 191, 84, 138, 99, 66, 18,
+                    175, 210, 246, 133, 149, 117, 78, 29,
+                    182, 77, 61, 21, 226, 50, 42, 136]
+            },
+            // GCKLKUWUDJNWPSTU7MEN55KFBKJMQIB7H5NQDJ7MGGQVNYIVHB5ZM5XP
+            {
+                address: "boa1xz2t25k5rfdk0jn5lvydaa29p2fvsgpl8adsrflvxxs4dcg48paevj87akp",
+                bytes: [
+                    148, 181, 82, 212, 26, 91, 103, 202,
+                    116, 251, 8, 222, 245, 69, 10, 146,
+                    200, 32, 63, 63, 91, 1, 167, 236,
+                    49, 161, 86, 225, 21, 56, 123, 150]
+            }
+        ];
+
+        addresses_bech32.forEach((m) =>
+        {
+            let data: Array<number> = [];
+            let conv_data: Array<number> = [];
+            let revert_data: Array<number> = [];
+
+            data.push(48);
+            data.push(...m.bytes);
+            boasdk.Utils.convertBits(conv_data, data, 8, 5, true);
+            boasdk.Utils.convertBits(revert_data, conv_data, 5, 8, false);
+            assert.deepStrictEqual(revert_data, data);
+
+            let addr_str = bech32.encode("boa", conv_data);
+            assert.deepStrictEqual(addr_str, m.address);
+
+            let dec = bech32.decode(m.address);
+            let dec_data: Array<number> = [];
+            assert.deepStrictEqual(dec.words, conv_data);
+            boasdk.Utils.convertBits(dec_data, dec.words, 5, 8, false);
+            assert.deepStrictEqual(dec_data, data);
+        });
+    });
+
     it ('Extract the public key from a string then convert it back into a string and compare it.', () =>
     {
-        let address = 'GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW';
+        let address = 'boa1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0';
         let public_key = new boasdk.PublicKey(address);
         assert.strictEqual(public_key.toString(), address);
     });
 
     it ('Test of PublicKey.validate()', () =>
     {
-        assert.strictEqual(boasdk.PublicKey.validate("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQF"), 'Decoded data size is not normal');
-        assert.strictEqual(boasdk.PublicKey.validate("SDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"), 'This is not a valid address type');
-        assert.strictEqual(boasdk.PublicKey.validate("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"), '');
+        assert.strictEqual(boasdk.PublicKey.validate("1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0"),
+            'Missing prefix for 1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0');
+        assert.strictEqual(boasdk.PublicKey.validate("bob1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0"),
+            'Invalid checksum for bob1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0');
+        assert.strictEqual(boasdk.PublicKey.validate("boa1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0"), '');
 
-        const decoded = Buffer.from(base32Decode("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"));
-        const body = decoded.slice(0, -2);
-        const checksum = decoded.slice(-2);
-        let invalid_decoded = Buffer.concat([body, checksum.map(n => ~n)]);
-        let invalid_address = base32Encode(invalid_decoded);
-        assert.strictEqual(boasdk.PublicKey.validate(invalid_address), 'Checksum result do not match');
+        let pk = new boasdk.PublicKey("boa1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0");
+        let data: Array<number> = [];
+        let conv_data: Array<number> = [];
+        data.push(48);
+        pk.data.forEach((m) => data.push(m));
+        let invalid_data = data.slice(0, -1);
+        boasdk.Utils.convertBits(conv_data, invalid_data, 8, 5, true);
+        let invalid_addr_str = bech32m.encode("boa", conv_data);
+        assert.strictEqual(boasdk.PublicKey.validate(invalid_addr_str), 'Decoded data size is not normal');
     });
 });
 
@@ -84,7 +212,7 @@ describe ('KeyPair', () =>
     // See: https://github.com/bosagora/agora/blob/bcd14f2c6a3616d7f05ef850dc95fae3eb386760/source/agora/crypto/Key.d#L391-L404
     it ('Test of KeyPair.fromSeed, sign, verify', () =>
     {
-        let address = `GDNODE2JBW65U6WVIOESR3OTJUFOHPHTEIL4GQINDB3MVB645KXAHG73`;
+        let address = `boa1xrdwry6fpk7a57k4gwyj3mwnf59w808nygtuxsgdrpmv4p7ua2hqx78z5en`;
         let seed = `SDV3GLVZ6W7R7UFB2EMMY4BBFJWNCQB5FTCXUMD5ZCFTDEVZZ3RQ2BZI`;
 
         let kp = boasdk.KeyPair.fromSeed(new boasdk.SecretKey(seed));

--- a/tests/TxBuilder.test.ts
+++ b/tests/TxBuilder.test.ts
@@ -42,7 +42,7 @@ describe ('TxBuilder', () =>
 
     it ('When trying to send the wrong amount', () =>
     {
-        let destination = new boasdk.PublicKey("GDNODE7J5EUK7T6HLEO2FDUBWZEXVXHJO7C4AF5VZAKZENGQ4WR3IX2U");
+        let destination = new boasdk.PublicKey("boa1xrdwryl0ajdd86c45w4zrjf8spmrt7u4l7s5jy64ac3dc78x2ucd7wkakac");
         let builder = new boasdk.TxBuilder(owner);
         let amount = JSBI.BigInt(0);
         builder.addInput(utxo_data1.utxo, utxo_data1.amount);
@@ -53,7 +53,7 @@ describe ('TxBuilder', () =>
 
     it ('When trying to send an amount greater than the amount of UTXO.', () =>
     {
-        let destination = new boasdk.PublicKey("GDNODE7J5EUK7T6HLEO2FDUBWZEXVXHJO7C4AF5VZAKZENGQ4WR3IX2U");
+        let destination = new boasdk.PublicKey("boa1xrdwryl0ajdd86c45w4zrjf8spmrt7u4l7s5jy64ac3dc78x2ucd7wkakac");
         let builder = new boasdk.TxBuilder(owner);
         let amount = utxo_data1.amount + BigInt(1);
         builder.addInput(utxo_data1.utxo, utxo_data1.amount);
@@ -64,7 +64,7 @@ describe ('TxBuilder', () =>
 
     it ('Test to create a transaction without data payload', () =>
     {
-        let destination = new boasdk.PublicKey("GDNODE7J5EUK7T6HLEO2FDUBWZEXVXHJO7C4AF5VZAKZENGQ4WR3IX2U");
+        let destination = new boasdk.PublicKey("boa1xrdwryl0ajdd86c45w4zrjf8spmrt7u4l7s5jy64ac3dc78x2ucd7wkakac");
         let builder = new boasdk.TxBuilder(owner);
         let tx: boasdk.Transaction;
         try {
@@ -85,14 +85,14 @@ describe ('TxBuilder', () =>
                 {
                     "utxo": "0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32",
                     "unlock": {
-                        "bytes": "6T6TFGKbFrd5RIJkLNRSU+dWv90lAi82SDNWLb55xT/9r8HMmhn/pyk3kmxgM6NS3xOo3+G+ZeaI41MStFTWAQ=="
+                        "bytes": "baLr3KhfUzr0WEYxYuQpthF8x+xIYihkWf+RnfXjldAGvnArN0hDVLcNZsHFCBaP2zKmRJm3sQUmKko7ZGlgDw=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef",
                     "unlock": {
-                        "bytes": "6T6TFGKbFrd5RIJkLNRSU+dWv90lAi82SDNWLb55xT/9r8HMmhn/pyk3kmxgM6NS3xOo3+G+ZeaI41MStFTWAQ=="
+                        "bytes": "2zY7qq/EKWQpAePoOjT4eFd3soO71EAE9P/E6PaLfzN5e4ZcxR9zZvsqH76pFgENlwTozYVARS6HRzY/l+FnBA=="
                     },
                     "unlock_age": 0
                 }
@@ -109,7 +109,7 @@ describe ('TxBuilder', () =>
                     "value": "20000000",
                     "lock": {
                         "type": 0,
-                        "bytes": "2uGT6ekor8/HWR2ijoG2SXrc6XfFwBe1yBWSNNDlo7Q="
+                        "bytes": "2uGT7+ya0+sVo6ohySeAdjX7lf+hSRNV7iLceOZXMN8="
                     }
                 }
             ],

--- a/tests/ValidationJSON.test.ts
+++ b/tests/ValidationJSON.test.ts
@@ -173,16 +173,16 @@ describe ('Test that JSON.stringify of Transaction', () =>
             [
                 new boasdk.TxOutput(
                     "1663400000",
-                    new boasdk.PublicKey("GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU")
+                    new boasdk.PublicKey("boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s")
                 ),
                 new boasdk.TxOutput(
                     "24398336600000",
-                    new boasdk.PublicKey("GDID227ETHPOMLRLIHVDJSNSJVLDS4D4ANYOUHXPMG2WWEZN5JO473ZO")
+                    new boasdk.PublicKey("boa1xrgr66gdm5je646x70l5ar6qkhun0hg3yy2eh7tf8xxlmlt9fgjd2q0uj8p")
                 )
             ],
             new boasdk.DataPayload("0x0001")
         )
         assert.strictEqual(JSON.stringify(tx),
-            `{"type":0,"inputs":[{"utxo":"0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32","unlock":{"bytes":"vaX+wxScBr2KIsPgKzku9kkGrfuQI8ar1eXWn9LoHxfWrLOmnliHjkGOGWk+QJ7urnpz9lRENrCMv9gsQZ4DCQ=="},"unlock_age":0}],"outputs":[{"value":"1663400000","lock":{"type":0,"bytes":"nMY5oTUvd/IlFgxC/4kaavpbRqEaaalJIIbXeAZ29Co="}},{"value":"24398336600000","lock":{"type":0,"bytes":"0D1r5Jne5i4rQeo0ybJNVjlwfANw6h7vYbVrEy3qXc8="}}],"payload":"0x0001","lock_height":"0"}`);
+            `{"type":0,"inputs":[{"utxo":"0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32","unlock":{"bytes":"vaX+wxScBr2KIsPgKzku9kkGrfuQI8ar1eXWn9LoHxfWrLOmnliHjkGOGWk+QJ7urnpz9lRENrCMv9gsQZ4DCQ=="},"unlock_age":0}],"outputs":[{"value":"1663400000","lock":{"type":0,"bytes":"xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM="}},{"value":"24398336600000","lock":{"type":0,"bytes":"0D1pDd0lnVdG8/9Oj0C1+TfdESEVm/lpOY39/WVKJNU="}}],"payload":"0x0001","lock_height":"0"}`);
     });
 });

--- a/tests/Vote.test.ts
+++ b/tests/Vote.test.ts
@@ -42,13 +42,13 @@ describe ('Vote Data', () =>
             "Title",
             boasdk.JSBI.BigInt(1000),
             boasdk.JSBI.BigInt(3026),
-            new boasdk.Hash(Buffer.allocUnsafe(boasdk.Hash.Width)),
+            new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
             boasdk.JSBI.BigInt(10000000000000),
             boasdk.JSBI.BigInt(100000000000),
-            boasdk.JSBI.BigInt(100000000),
-            new boasdk.Hash(Buffer.allocUnsafe(boasdk.Hash.Width)),
-            new boasdk.PublicKey("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"),
-            new boasdk.PublicKey("GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU")
+            boasdk.JSBI.BigInt(27000000),
+            new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
+            new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e"),
+            new boasdk.PublicKey("boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s")
             );
         let bytes = new SmartBuffer();
         original_data.serialize(bytes);
@@ -152,13 +152,13 @@ describe ('Vote Data', () =>
     it ('Test link data of ProposalFeeData', () =>
     {
         let data = new boasdk.ProposalFeeData("ID1234567890");
-        let proposal_address = new boasdk.PublicKey("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW");
-        let destination = new boasdk.PublicKey("GDPU22KOCCNMCACFVN3BGDNC4NWXKQ4YGMZ75X4JXMNS7LO5IBQWB7CJ");
+        let proposal_address = new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e");
+        let destination = new boasdk.PublicKey("boa1xrgq6607dulyra5r9dw0ha6883va0jghdzk67er49h3ysm7k222ruhh7400");
         let amount = boasdk.JSBI.BigInt("10000000000000")
         let link_data = data.getLinkData(proposal_address, destination, amount);
         let expected = {
-            proposer_address: 'GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW',
-            destination: 'GDPU22KOCCNMCACFVN3BGDNC4NWXKQ4YGMZ75X4JXMNS7LO5IBQWB7CJ',
+            proposer_address: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
+            destination: 'boa1xrgq6607dulyra5r9dw0ha6883va0jghdzk67er49h3ysm7k222ruhh7400',
             amount: '10000000000000',
             payload: 'CFBST1AtRkVFDElEMTIzNDU2Nzg5MA=='
         }
@@ -178,34 +178,34 @@ describe ('Vote Data', () =>
             boasdk.JSBI.BigInt(100000000000),
             boasdk.JSBI.BigInt(100000000),
             new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
-            new boasdk.PublicKey("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"),
-            new boasdk.PublicKey("GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU")
+            new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e"),
+            new boasdk.PublicKey("boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s")
         );
-        let proposal_address = new boasdk.PublicKey("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW");
+        let proposer_address = new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e");
         let validators = [
-            new boasdk.PublicKey("GDPU22KOCCNMCACFVN3BGDNC4NWXKQ4YGMZ75X4JXMNS7LO5IBQWB7CJ"),
-            new boasdk.PublicKey("GDPV22UHJUZKPO4SDIZBNZXNKDFFSPLRHC3VPBO2TUBP2Y4LHGZYCP4L"),
-            new boasdk.PublicKey("GDPW227UM2JOHIV7ASZPZ7KQ6DP2V2QX4VHLSKZX27545YBYFS7FZWFK"),
-            new boasdk.PublicKey("GDPX22XXTETXC4YJCMGMI55OBGUVIXVL5AOKP2RGT24B4HCGBRIPFHHD"),
-            new boasdk.PublicKey("GDPY22WMCY3TH5OUZRRN2CZF4I6UFBV3VDT627HCQMQCQAR7M2WQ5UT4"),
-            new boasdk.PublicKey("GDPZ225K4MUNOHGEYKP4RWBFXCHL6TXDLHZYRNGRXQ2MGGLTUSUCUNA7"),
-            new boasdk.PublicKey("GDQA224KNN7LBDRWG3VFL72DRZGKKLNYE4RB6NWP4HX26WKPPEWLNYWW"),
+            new boasdk.PublicKey("boa1xrdwry6fpk7a57k4gwyj3mwnf59w808nygtuxsgdrpmv4p7ua2hqx78z5en"),
+            new boasdk.PublicKey("boa1xrdwrymw40ae7kdumk5uf24rf7wj6kxeem0t3mh9yclz6j46rnen6htq9ju"),
+            new boasdk.PublicKey("boa1xrdwryuhc2tw2j97wqe3ahh37qnjya59n5etz88n9fvwyyt9jyvrvfq5ecp"),
+            new boasdk.PublicKey("boa1xrdwryayr9r3nacx26vwe6ymy2kl7zp7dc03q5h6zk65vnu6mtkkzdqg39f"),
+            new boasdk.PublicKey("boa1xrdwry7vltf9mrzf62qgpdh282grqn9nlnvhzp0yt8y0y9zedmgh64s2qjg"),
+            new boasdk.PublicKey("boa1xrdwryl0ajdd86c45w4zrjf8spmrt7u4l7s5jy64ac3dc78x2ucd7wkakac"),
+            new boasdk.PublicKey("boa1xrgr66gdm5je646x70l5ar6qkhun0hg3yy2eh7tf8xxlmlt9fgjd2q0uj8p"),
         ];
         let voting_fee = boasdk.JSBI.BigInt("12000000")
-        let link_data = data.getLinkData(proposal_address, validators, voting_fee);
+        let link_data = data.getLinkData(proposer_address, validators, voting_fee);
         let expected = {
-            proposer_address: 'GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW',
+            proposer_address: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             validators: [
-                'GDPU22KOCCNMCACFVN3BGDNC4NWXKQ4YGMZ75X4JXMNS7LO5IBQWB7CJ',
-                'GDPV22UHJUZKPO4SDIZBNZXNKDFFSPLRHC3VPBO2TUBP2Y4LHGZYCP4L',
-                'GDPW227UM2JOHIV7ASZPZ7KQ6DP2V2QX4VHLSKZX27545YBYFS7FZWFK',
-                'GDPX22XXTETXC4YJCMGMI55OBGUVIXVL5AOKP2RGT24B4HCGBRIPFHHD',
-                'GDPY22WMCY3TH5OUZRRN2CZF4I6UFBV3VDT627HCQMQCQAR7M2WQ5UT4',
-                'GDPZ225K4MUNOHGEYKP4RWBFXCHL6TXDLHZYRNGRXQ2MGGLTUSUCUNA7',
-                'GDQA224KNN7LBDRWG3VFL72DRZGKKLNYE4RB6NWP4HX26WKPPEWLNYWW'
+                'boa1xrdwry6fpk7a57k4gwyj3mwnf59w808nygtuxsgdrpmv4p7ua2hqx78z5en',
+                'boa1xrdwrymw40ae7kdumk5uf24rf7wj6kxeem0t3mh9yclz6j46rnen6htq9ju',
+                'boa1xrdwryuhc2tw2j97wqe3ahh37qnjya59n5etz88n9fvwyyt9jyvrvfq5ecp',
+                'boa1xrdwryayr9r3nacx26vwe6ymy2kl7zp7dc03q5h6zk65vnu6mtkkzdqg39f',
+                'boa1xrdwry7vltf9mrzf62qgpdh282grqn9nlnvhzp0yt8y0y9zedmgh64s2qjg',
+                'boa1xrdwryl0ajdd86c45w4zrjf8spmrt7u4l7s5jy64ac3dc78x2ucd7wkakac',
+                'boa1xrgr66gdm5je646x70l5ar6qkhun0hg3yy2eh7tf8xxlmlt9fgjd2q0uj8p'
             ],
             voting_fee: '12000000',
-            payload: 'CFBST1BPU0FMAQxJRDEyMzQ1Njc4OTAFVGl0bGX96AP90gsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/wCgck4YCQAA/wDodkgXAAAA/gDh9QUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAx9iUwUUAUTrwBrnguo84lfyvTZHHT46ge180pVV6WNWcxjmhNS938iUWDEL/iRpq+ltGoRppqUkghtd4Bnb0Kg=='
+            payload: 'CFBST1BPU0FMAQxJRDEyMzQ1Njc4OTAFVGl0bGX96AP90gsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/wCgck4YCQAA/wDodkgXAAAA/gDh9QUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3a06L4woZ9MyLzmmyxStuZUWXlW7dSjABgawSp4S3brE5jHa/ppbHr2cAIgUg1wysLK1cmZxbL33835mUYQhYw=='
         };
         assert.deepStrictEqual(link_data, expected);
     });

--- a/tests/Votera.test.ts
+++ b/tests/Votera.test.ts
@@ -24,8 +24,8 @@ let sample_txs_history =
     [
         {
             display_tx_type: 'payload',
-            address: 'GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '100',
             time: 1600353600,
@@ -37,8 +37,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'payload',
-            address: 'GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 10,
             height: '8',
             time: 1600953600,
@@ -50,8 +50,8 @@ let sample_txs_history =
         },
         {
             display_tx_type: 'payload',
-            address: 'GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I',
-            peer: 'GDO22PFYWMU3YFLKDYP2PVM4PLX2D4BLJ2IRQMIHWJHFS3TZ6ITJMGPU',
+            address: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
+            peer: 'boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e',
             peer_count: 1,
             height: '9',
             time: 1601553600,
@@ -130,7 +130,7 @@ export class TestStoa {
                                 new boasdk.TxInput(new boasdk.Hash("0xc0abcbff07879bfdb1495b8fdb9a9e5d2b07a689c7b9b3c583459082259be35687c125a1ddd6bd28b4fe8533ff794d3dba466b5f91117bbf557c3f1b6ff50e5f"))
                             ],
                             [
-                                new boasdk.TxOutput("100000000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU")))
+                                new boasdk.TxOutput("100000000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s")))
                             ],
                             new boasdk.DataPayload(Buffer.from("CFBST1AtRkVFDElEMTIzNDU2Nzg5MA==", "base64"))
                         );
@@ -144,17 +144,17 @@ export class TestStoa {
                                 new boasdk.TxInput(new boasdk.Hash("0xc0abcbff07879bfdb1495b8fdb9a9e5d2b07a689c7b9b3c583459082259be35687c125a1ddd6bd28b4fe8533ff794d3dba466b5f91117bbf557c3f1b6ff50e5f"))
                             ],
                             [
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDB22QJ4NHOHPOGWZG2Y5IFXKW6DCBEFX6QNBR6NSCT6E7CYU66IDGJJ"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDD22H4TGRGS5ENN3DHBGMMCSZELKORKEZT4SZKTKHZESTVQMONREB2D"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDF22EW2CZW2KVRSLFNGJQOTTDH5XWOK7MLINZPWO526WWXJMDXU3DPI"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDE22BZJPPMELAQUZBQR7GTILNHMSUHS5J2BVMKU36LPW3SSKQU737SP"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDK223SKRC2QD3FFIXSZJRL6SKQI4MLJNVJB4FE356OEIVVGWGBAWLRM"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDJ227UY64U4VLOW773KIT64RHHRZKRZFA7YS7MFMJK5WUDEQCEEEJUW"))),
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDP22NLZYRX2TBOBWTG46YCHB7WV76J56TMDZO5TDUQPIL7NCM4Q7TGU"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8q66jvs4xye4yx80vv0rrv7gh0quue3jrntl7tkseagj3t07767tg808f"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8p66enrg38qshzn6slnqe3fye6g6xa42kj8hm364yn238ks5ywc59nwyj"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8z66s0dcagyd57ykfwm3yplgv4x6zasf42hxn5gkmx0lxjtceq7my0vqc"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8r66fcuywd6kp7y9ywslwqlsf8rxtajt8pw53rj39wxfwvkxp2663dajh"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8y66e3rjm0fpj9s59r44l8nplfnplhhj6pya0cg5ejsr3ues92jmdztnm"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8966pz0jyxgxrjatp6tuplnhzmaulj9rsuahrxjcr5cu8jxh2hsapmc6y"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8x66qtpp9fd6w8wtmwk9e9k3e7gur0vvjs9axd4gxm36avm8cxczdenyu"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr88665hn7nlz60230tc80ymq6r3mvzhvjzx9sg3lnkjmqy0w4ne22637v6"))),
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xr8g66r5xa9qj5dcpp322pnk9706k8rvlhsynx9qk8lpeasw85022lnxadw"))),
                             ],
-                            new boasdk.DataPayload(Buffer.from("CFBST1BPU0FMAQxJRDEyMzQ1Njc4OTAFVGl0bGX96AP90gsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/wCgck4YCQAA/wDodkgXAAAA/sD8mwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAx9iUwUUAUTrwBrnguo84lfyvTZHHT46ge180pVV6WNWcxjmhNS938iUWDEL/iRpq+ltGoRppqUkghtd4Bnb0Kg==", "base64"))
+                            new boasdk.DataPayload(Buffer.from("CFBST1BPU0FMAQxJRDEyMzQ1Njc4OTAFVGl0bGX96AP90gsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/wCgck4YCQAA/wDodkgXAAAA/sD8mwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3a06L4woZ9MyLzmmyxStuZUWXlW7dSjABgawSp4S3brE5jHa/ppbHr2cAIgUg1wysLK1cmZxbL33835mUYQhYw==", "base64"))
                         );
                         res.status(200).send(JSON.stringify(tx));
                     }
@@ -166,7 +166,7 @@ export class TestStoa {
                                 new boasdk.TxInput(new boasdk.Hash("0xc0abcbff07879bfdb1495b8fdb9a9e5d2b07a689c7b9b3c583459082259be35687c125a1ddd6bd28b4fe8533ff794d3dba466b5f91117bbf557c3f1b6ff50e5f"))
                             ],
                             [
-                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I")))
+                                new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e")))
                             ],
                             new boasdk.DataPayload(Buffer.from("CEJBTExPVCAgDElEMTIzNDU2Nzg5MCnNDXqsIjf122wQG3k9SKb580hRF7MXqyls/Wjq7dxrztafXvbMlKQnLMWtIp2TBufIJIhInD6XvqjImZjxWdzHSZiNYVXVuKDmx60Co13nUDL3h+pKXCsG460FHRgDZWnJFfTYnch/tLj+gJaYAJGWUGjimvGZAq2HVp9kC3ClurMEA05RNDV484T/bh8I86ZoO4yFlkiLwOf+QOtUR0Qf65D2Rg2yq5V+YT05AAJkbTtR5m+izCVSoIcXz4+Nju9lq2K/FkcdJGrAsrYiRoPuerQHTl9HopfqdZDjFO4gcciSaI5x5mws87fLGSL9AQ==", "base64"))
                         );
@@ -328,21 +328,21 @@ describe('Checking the proposal and ballot data', () =>
             proposal_fee: boasdk.JSBI.BigInt(100000000000),
             vote_fee: boasdk.JSBI.BigInt(27000000),
             tx_hash_proposal_fee: new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
-            proposer_address: new boasdk.PublicKey("GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW"),
-            proposal_fee_address: new boasdk.PublicKey("GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU")
+            proposer_address: new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e"),
+            proposal_fee_address: new boasdk.PublicKey("boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s")
         }
 
         let validators =
             [
-                "GDB22QJ4NHOHPOGWZG2Y5IFXKW6DCBEFX6QNBR6NSCT6E7CYU66IDGJJ",
-                "GDD22H4TGRGS5ENN3DHBGMMCSZELKORKEZT4SZKTKHZESTVQMONREB2D",
-                "GDG22B5FTPXE5THQMCTGDUC4LF2N4DFF44PGX2LIFG4WNUZZAT4L6ZGD",
-                "GDF22EW2CZW2KVRSLFNGJQOTTDH5XWOK7MLINZPWO526WWXJMDXU3DPI",
-                "GDA225RGC4GOCVASSAMROSWJSGNOZX2IGPXZG52ESDSKQW2VN6UJFKWI",
-                "GDE22BZJPPMELAQUZBQR7GTILNHMSUHS5J2BVMKU36LPW3SSKQU737SP",
-                "GDK223SKRC2QD3FFIXSZJRL6SKQI4MLJNVJB4FE356OEIVVGWGBAWLRM",
-                "GDJ227UY64U4VLOW773KIT64RHHRZKRZFA7YS7MFMJK5WUDEQCEEEJUW",
-                "GDP22NLZYRX2TBOBWTG46YCHB7WV76J56TMDZO5TDUQPIL7NCM4Q7TGU"
+                "boa1xr8q66jvs4xye4yx80vv0rrv7gh0quue3jrntl7tkseagj3t07767tg808f",
+                "boa1xr8p66enrg38qshzn6slnqe3fye6g6xa42kj8hm364yn238ks5ywc59nwyj",
+                "boa1xr8z66s0dcagyd57ykfwm3yplgv4x6zasf42hxn5gkmx0lxjtceq7my0vqc",
+                "boa1xr8r66fcuywd6kp7y9ywslwqlsf8rxtajt8pw53rj39wxfwvkxp2663dajh",
+                "boa1xr8y66e3rjm0fpj9s59r44l8nplfnplhhj6pya0cg5ejsr3ues92jmdztnm",
+                "boa1xr8966pz0jyxgxrjatp6tuplnhzmaulj9rsuahrxjcr5cu8jxh2hsapmc6y",
+                "boa1xr8x66qtpp9fd6w8wtmwk9e9k3e7gur0vvjs9axd4gxm36avm8cxczdenyu",
+                "boa1xr88665hn7nlz60230tc80ymq6r3mvzhvjzx9sg3lnkjmqy0w4ne22637v6",
+                "boa1xr8g66r5xa9qj5dcpp322pnk9706k8rvlhsynx9qk8lpeasw85022lnxadw"
             ];
 
         // Set URL
@@ -353,7 +353,7 @@ describe('Checking the proposal and ballot data', () =>
         let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
 
         // It queries the last 10 transactions that have a data payload of a particular address.
-        let public_key = new boasdk.PublicKey("GDML22LKP3N6S37CYIBFRANXVY7KMJMINH5VFADGDFLGIWNOR3YU7T6I");
+        let public_key = new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e");
         let history = await boa_client.getWalletTransactionsHistory(public_key, 10, 1, ["payload"]);
 
         for (let idx = 0; idx < history.length; idx++)


### PR DESCRIPTION
Recently, the way Agora's public address is printed as a string has been changed.
I adapted to SDK for this change.


Related to https://github.com/bosagora/agora/issues/1655