### PR TITLE
Change the method of calculating hash values to the same as Agora

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "The TypeScript BOA SDK library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/modules/common/KeyPair.ts
+++ b/src/modules/common/KeyPair.ts
@@ -82,9 +82,9 @@ export class KeyPair
      * @returns The signature of `msg` using `this`
      * See_Also: https://github.com/bosagora/agora/blob/bcd14f2c6a3616d7f05ef850dc95fae3eb386760/source/agora/crypto/Key.d#L91-L95
      */
-    public sign (msg: Buffer): Signature
+    public sign <T> (msg: T): Signature
     {
-        return Schnorr.signPair<Buffer>(new Pair(this.secret.scalar, this.address.point), msg);
+        return Schnorr.signPair<T>(new Pair(this.secret.scalar, this.address.point), msg);
     }
 }
 
@@ -213,9 +213,9 @@ export class PublicKey
      * @returns `true` if the signature is valid
      * See_Also: https://github.com/bosagora/agora/blob/bcd14f2c6a3616d7f05ef850dc95fae3eb386760/source/agora/crypto/Key.d#L242-L246
      */
-    public verify (signature: Signature, msg: Buffer): boolean
+    public verify <T> (signature: Signature, msg: T): boolean
     {
-        return Schnorr.verify<Buffer>(this.point, signature, msg);
+        return Schnorr.verify<T>(this.point, signature, msg);
     }
 
     /**
@@ -316,9 +316,9 @@ export class SecretKey
      * @param msg The message to sign.
      * @returns The signature of `msg` using `this`
      */
-    public sign (msg: Buffer): Signature
+    public sign <T> (msg: T): Signature
     {
-        return Schnorr.signPair<Buffer>(Pair.fromScalar(this.scalar), msg);
+        return Schnorr.signPair<T>(Pair.fromScalar(this.scalar), msg);
     }
 
     /**

--- a/src/modules/data/DataPayload.ts
+++ b/src/modules/data/DataPayload.ts
@@ -11,6 +11,7 @@
 
 *******************************************************************************/
 
+import { hashPart } from '../common/Hash';
 import { JSONValidator } from "../utils/JSONValidator";
 import { Utils, Endian } from '../utils/Utils';
 
@@ -113,7 +114,7 @@ export class DataPayload
      */
     public computeHash (buffer: SmartBuffer)
     {
-        buffer.writeBuffer(this.data);
+        hashPart(this.data, buffer);
     }
 
     /**

--- a/src/modules/data/Transaction.ts
+++ b/src/modules/data/Transaction.ts
@@ -11,6 +11,7 @@
 
 *******************************************************************************/
 
+import { hashPart } from '../common/Hash';
 import { DataPayload } from './DataPayload';
 import { Height } from '../common/Height';
 import { JSONValidator } from '../utils/JSONValidator';
@@ -113,10 +114,8 @@ export class Transaction
     public computeHash (buffer: SmartBuffer)
     {
         buffer.writeUInt8(this.type);
-        for (let elem of this.inputs)
-            elem.computeHash(buffer);
-        for (let elem of this.outputs)
-            elem.computeHash(buffer);
+        hashPart(this.inputs, buffer);
+        hashPart(this.outputs, buffer);
         this.payload.computeHash(buffer);
 
         const buf = Buffer.allocUnsafe(8);

--- a/src/modules/script/Lock.ts
+++ b/src/modules/script/Lock.ts
@@ -35,6 +35,7 @@
 
 *******************************************************************************/
 
+import { hashPart } from '../common/Hash';
 import { PublicKey } from '../common/KeyPair';
 import { Signature } from '../common/Signature';
 import { JSONValidator } from '../..';
@@ -112,7 +113,7 @@ export class Lock
     public computeHash (buffer: SmartBuffer)
     {
         buffer.writeUInt8(this.type);
-        buffer.writeBuffer(this.bytes);
+        hashPart(this.bytes, buffer);
     }
 
     /**

--- a/src/modules/utils/TxBuilder.ts
+++ b/src/modules/utils/TxBuilder.ts
@@ -211,7 +211,7 @@ export class TxBuilder
      */
     private keyUnlocker (tx: Transaction, raw_input: RawInput, idx: number): Unlock
     {
-        return Unlock.fromSignature(raw_input.key.sign(hashFull(tx).data));
+        return Unlock.fromSignature(raw_input.key.sign<Transaction>(tx));
     }
 }
 

--- a/src/modules/vote/BallotData.ts
+++ b/src/modules/vote/BallotData.ts
@@ -72,8 +72,7 @@ export class VoterCard
      */
     public verify (): boolean
     {
-        let voter_card_hash = hashFull(this);
-        return this.validator_address.verify(this.signature, voter_card_hash.data);
+        return this.validator_address.verify<VoterCard>(this.signature, this);
     }
 
     /**
@@ -199,8 +198,7 @@ export class BallotData
      */
     public verify (): boolean
     {
-        let ballot_data_hash = hashFull(this);
-        return this.card.address.verify(this.signature, ballot_data_hash.data);
+        return this.card.address.verify<BallotData>(this.signature, this);
     }
 
     /**

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -1111,8 +1111,8 @@ describe('BOA Client', () => {
 
         // Verify the signature
         for (let idx = 0; idx < vote_tx.inputs.length; idx++)
-            assert.ok(keys[idx].address.verify(new boasdk.Signature(vote_tx.inputs[idx].unlock.bytes),
-                boasdk.hashFull(vote_tx).data));
+            assert.ok(keys[idx].address.verify<boasdk.Transaction>(new boasdk.Signature(vote_tx.inputs[idx].unlock.bytes),
+                vote_tx));
     });
 
     it ('Test saving a vote data', async () =>

--- a/tests/Hash.test.ts
+++ b/tests/Hash.test.ts
@@ -37,6 +37,7 @@ describe('Hash', () =>
             'c369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73');
     });
 
+    // The test codes below compare with the values calculated in Agora.
     it('Test of hash("abc")', () => {
         // Hash
         let h = boasdk.hash(Buffer.from("abc"));
@@ -47,7 +48,7 @@ describe('Hash', () =>
             'dd1a2ffdb6fbb124bb7c45a68142f214ce9f6129fb697276a0d4d1c983fa580ba');
     });
 
-    // https://github.com/bosagora/agora/blob/v0.x.x/source/agora/common/Hash.d#L260-L265
+    // The test codes below compare with the values calculated in Agora.
     it('Test of multi hash', () => {
         // Source 1 : "foo"
         let foo = boasdk.hash(Buffer.from("foo"));
@@ -64,6 +65,7 @@ describe('Hash', () =>
             'c2e756f276c112342ff1d6f1e74d05bdb9bf880abd74a2e512654e12d171a74');
     });
 
+    // The test codes below compare with the values calculated in Agora.
     it('Test of utxo key, using makeUTXOKey', () => {
         let tx_hash = new boasdk.Hash('0x5d7f6a7a30f7ff591c8649f61eb8a35d034824ed5cd252c2c6f10cdbd223671' +
             '3dc369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73');
@@ -74,7 +76,7 @@ describe('Hash', () =>
             'e33bb2b89df2e59ee01eb2519b1508284b577f66a76d42546b65a6813e592bb84');
     });
 
-    // See_Also: https://github.com/bosagora/agora/blob/dac8b3ea6500af68a99c0248c3ade8ab821ee9ef/source/agora/consensus/data/Transaction.d#L203-L229
+    // The test codes below compare with the values calculated in Agora.
     it ('Test for hash value of transaction data', () =>
     {
         let payment_tx = new boasdk.Transaction(
@@ -88,8 +90,8 @@ describe('Hash', () =>
             boasdk.DataPayload.init
         );
         assert.strictEqual(boasdk.hashFull(payment_tx).toString(),
-            "0x6dbcc8c36bd1f95986d8b06a6bad320b0719e14bb1afe2cf824618c3311a23b" +
-            "5ac9c35f474dc67182cf17bb609f46e4049f793b996321f6fad88a2925badf198");
+            "0xef5d99551a2d15e723f77a468fcd1d1a9635d0ff2eb6924445e8b005108e0c7" +
+            "007c60135014a46c4513bfaaa3c6e0ff826c28c86f63c8976f5c5527599d46bac");
 
         let nBytes =
             boasdk.Utils.SIZE_OF_BYTE +     //  Transaction.type
@@ -115,13 +117,28 @@ describe('Hash', () =>
         );
 
         assert.strictEqual(boasdk.hashFull(freeze_tx).toString(),
-            "0xf028cecf9498bc615e3ac4ff18efa98c6428b8af1f26a2cfa73518d039a4f2e" +
-            "f4f600f28cd25403ad588f0d42e3987863bbd26cdd28b136fee4b80b7f0cc061a");
+            "0x9f7f610a6b2689b2c88ec3c62bbd7cf393737700f660793d6642b2852773de0" +
+            "abc2c0d4bb3a7d4a807dfd869f88e91e28471f6a4d2c990442b9c250585c25051");
 
         assert.strictEqual(freeze_tx.getNumberOfBytes(), nBytes);
+
+
+        let payload_tx = new boasdk.Transaction(
+            boasdk.TxType.Payment,
+            [
+                boasdk.TxInput.fromTxHash(new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)), JSBI.BigInt(0))
+            ],
+            [
+                new boasdk.TxOutput("0", boasdk.Lock.Null)
+            ],
+            new boasdk.DataPayload(Buffer.from([1,2,3]))
+        );
+        assert.strictEqual(boasdk.hashFull(payload_tx).toString(),
+            "0xfa416b96ef0b6d81ae246e3de6a992c9afabd1f53c336dceec47fd462e69948" +
+            "da328a86330c228de06ef9c101d3294722675af08e576670e91533117f75b6976");
     });
 
-    // See_Also: https://github.com/bosagora/agora/blob/73a7cd593afab6726021e05cf16b90d246343d65/source/agora/consensus/data/Block.d#L118-L138
+    // The test codes below compare with the values calculated in Agora.
     it ('Test for hash value of BlockHeader', () =>
     {
         let pubkey = new boasdk.PublicKey('boa1xrr66q4rthn4qvhhsl4y5hptqm366pgarqpk26wfzh6d38wg076tsqqesgg');
@@ -137,7 +154,7 @@ describe('Hash', () =>
             new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
             new boasdk.Height("0"),
             boasdk.hashFull(tx),
-            new boasdk.BitField([ ]),
+            new boasdk.BitField([0]),
             new boasdk.Signature(Buffer.alloc(boasdk.Signature.Width)),
             [ ],
             new boasdk.Hash(Buffer.alloc(boasdk.Hash.Width)),
@@ -145,10 +162,11 @@ describe('Hash', () =>
             0
         );
         assert.strictEqual(boasdk.hashFull(header).toString(),
-            "0xae5eb320aec482edb3fa2ab8eb3c7577f9fe10beaba95eb46e72b39b4053b79" +
-            "74da42afeb1d34439c7a57b5b3dc6df4d46f72870138636decd5e60b367612138");
+            "0x41a6bb62adc1e7448bc134090f23e511292224189134fffc597943d5f63d4da" +
+            "6d0a605ccc1179697f884b3f4df0558eb67612ca75cf9332f4b5b04caebe761c9");
     });
 
+    // The test codes below compare with the values calculated in Agora.
     it ('Test for hash value of BlockHeader with missing validators', () =>
     {
         let pubkey = new boasdk.PublicKey('boa1xrr66q4rthn4qvhhsl4y5hptqm366pgarqpk26wfzh6d38wg076tsqqesgg');
@@ -172,7 +190,36 @@ describe('Hash', () =>
             0
         );
         assert.strictEqual(boasdk.hashFull(header).toString(),
-            "0x252c0ef24da4ba4d4302b8b14eadfb8a4ba87862ff75acd8a7c801e3c55dbb8" +
-            "6307f5208ceb2b8095630cfb5d9e28dbc709824df85bed906a05a1005a076c672");
+            "0xe46f7b96a5dfce78c4590b25242cc42a1d30868a7a74460a8e3eeabbe12055f" +
+            "d62a475e76e6a623a34e5618769f816c7c9233bbbf1e23aeb5f46584e21f0efa2");
+    });
+
+    // The test codes below compare with the values calculated in Agora.
+    it ("Test for hash value of Scalar", () =>
+    {
+        let scalar = new boasdk.Scalar(
+            "0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
+        assert.deepStrictEqual(boasdk.hashFull(scalar).toString(),
+            "0x4f895cc641b2bfe4541f53b83445add00a7a81ad340312c51cbf15c53ddebcc" +
+            "7ea7dcd11a97e085d28552026952e7c7c8d4276d5901d33605a3ea21027a673d4");
+    });
+
+    // The test codes below compare with the values calculated in Agora.
+    it ("Test for hash value of Point", () =>
+    {
+        let point = new boasdk.Point(
+            "0xdb445140a72012a177535f43e6bbb8523ff21de465a7c35b42be1a447e5e2908")
+        assert.deepStrictEqual(boasdk.hashFull(point).toString(),
+            "0xa0ad987cffcf2e3f96af64dd197d95d4e8e41be4448f6abebd8953b3c37b313" +
+            "2a1a1917c2046f6d3550cac70299110b28f23454d6124892ab2b8a6508f2bfe47");
+    });
+
+    // The test codes below compare with the values calculated in Agora.
+    it ("Test for hash value of PublicKey", () =>
+    {
+        let publicKey = new boasdk.PublicKey('boa1xrr66q4rthn4qvhhsl4y5hptqm366pgarqpk26wfzh6d38wg076tsqqesgg');
+        assert.deepStrictEqual(boasdk.hashFull(publicKey).toString(),
+            "0x774d28bb3dc06a1418a4165109f4e8e4e05b4b283c798dd10aa70050a9b0954" +
+            "08b3d1c6c1017b69912e94a4a58c5cb522e78b9741e1380bb5d2d705116f886ef");
     });
 });

--- a/tests/KeyPair.test.ts
+++ b/tests/KeyPair.test.ts
@@ -218,22 +218,22 @@ describe ('KeyPair', () =>
         let kp = boasdk.KeyPair.fromSeed(new boasdk.SecretKey(seed));
         assert.strictEqual(kp.address.toString(), address);
 
-        let signature = kp.secret.sign(Buffer.from('Hello World'));
-        assert.ok(kp.address.verify(signature, Buffer.from('Hello World')));
+        let signature = kp.secret.sign<Buffer>(Buffer.from('Hello World'));
+        assert.ok(kp.address.verify<Buffer>(signature, Buffer.from('Hello World')));
     });
 
     it ('Test of KeyPair.random, sign, verify, reproduce', () =>
     {
         let random_kp = boasdk.KeyPair.random();
 
-        let random_kp_signature = random_kp.secret.sign(Buffer.from('Hello World'));
-        assert.ok(random_kp.address.verify(random_kp_signature, Buffer.from('Hello World')));
+        let random_kp_signature = random_kp.secret.sign<Buffer>(Buffer.from('Hello World'));
+        assert.ok(random_kp.address.verify<Buffer>(random_kp_signature, Buffer.from('Hello World')));
 
         // Test whether randomly generated key-pair are reproducible.
         let reproduced_kp = boasdk.KeyPair.fromSeed(random_kp.secret);
 
-        let reproduced_kp_signature = reproduced_kp.secret.sign(Buffer.from('Hello World'));
-        assert.ok(reproduced_kp.address.verify(reproduced_kp_signature, Buffer.from('Hello World')));
+        let reproduced_kp_signature = reproduced_kp.secret.sign<Buffer>(Buffer.from('Hello World'));
+        assert.ok(reproduced_kp.address.verify<Buffer>(reproduced_kp_signature, Buffer.from('Hello World')));
 
         assert.deepStrictEqual(random_kp.secret, reproduced_kp.secret);
         assert.deepStrictEqual(random_kp.address, reproduced_kp.address);

--- a/tests/Vote.test.ts
+++ b/tests/Vote.test.ts
@@ -70,8 +70,7 @@ describe ('Vote Data', () =>
         let temporary_key = boasdk.KeyPair.random();
 
         let voter_card = new boasdk.VoterCard(validator_key.address, temporary_key.address, JSBI.BigInt(Date.now().valueOf()));
-        let voter_card_hash = boasdk.hashFull(voter_card);
-        voter_card.signature = validator_key.secret.sign(voter_card_hash.data);
+        voter_card.signature = validator_key.secret.sign<boasdk.VoterCard>(voter_card);
 
         assert.ok(voter_card.verify());
 
@@ -83,8 +82,7 @@ describe ('Vote Data', () =>
         //  This is sample
         let ballot = Buffer.from("Yes  ");
         let ballot_data = new boasdk.BallotData("Votera", "ID1234567890", ballot, voter_card, 100);
-        let ballot_data_hash = boasdk.hashFull(ballot_data);
-        ballot_data.signature = temporary_key.secret.sign(ballot_data_hash.data);
+        ballot_data.signature = temporary_key.secret.sign<boasdk.BallotData>(ballot_data);
 
         assert.ok(ballot_data.verify());
 
@@ -130,8 +128,7 @@ describe ('Vote Data', () =>
         // The temporary KeyPair
         let temporary_key = boasdk.KeyPair.random();
         let voter_card = new boasdk.VoterCard(validator_key.address, temporary_key.address, JSBI.BigInt(Date.now().valueOf()));
-        let voter_card_hash = boasdk.hashFull(voter_card);
-        voter_card.signature = validator_key.secret.sign(voter_card_hash.data);
+        voter_card.signature = validator_key.secret.sign<boasdk.VoterCard>(voter_card);
 
         //  This is sample
         let pre_image = new boasdk.Hash('0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328');
@@ -141,8 +138,7 @@ describe ('Vote Data', () =>
         let key_encrypt = boasdk.Encrypt.createKey(key_agora_admin.data, proposal_id);
         let ballot = boasdk.Encrypt.encrypt(Buffer.from([boasdk.BallotData.BLANK]), key_encrypt);
         let ballot_data = new boasdk.BallotData(app_name, proposal_id, ballot, voter_card, 100);
-        let ballot_data_hash = boasdk.hashFull(ballot_data);
-        ballot_data.signature = temporary_key.secret.sign(ballot_data_hash.data);
+        ballot_data.signature = temporary_key.secret.sign<boasdk.BallotData>(ballot_data);
 
         let ballot_bytes = new SmartBuffer();
         ballot_data.serialize(ballot_bytes);
@@ -221,8 +217,7 @@ describe ('Vote Data', () =>
         let temporary_key = boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SANGEY2BIMFZ3K3T3NWSVYBS65N55SZE7WBEVVXQFLLZI6GLZBKACO6G"));
 
         let voter_card = new boasdk.VoterCard(validator_key.address, temporary_key.address, boasdk.JSBI.BigInt(10000000));
-        let voter_card_hash = boasdk.hashFull(voter_card);
-        voter_card.signature = validator_key.secret.sign(voter_card_hash.data);
+        voter_card.signature = validator_key.secret.sign<boasdk.VoterCard>(voter_card);
 
         let pre_image = new boasdk.Hash('0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328');
         let app_name = "Votera";
@@ -231,12 +226,11 @@ describe ('Vote Data', () =>
         let key_encrypt = boasdk.Encrypt.createKey(key_agora_admin.data, proposal_id);
         let ballot = boasdk.Encrypt.encrypt(Buffer.from([boasdk.BallotData.YES]), key_encrypt);
         let ballot_data = new boasdk.BallotData(app_name, "ID1234567890", ballot, voter_card, 100);
-        let ballot_data_hash = boasdk.hashFull(ballot_data);
-        ballot_data.signature = temporary_key.secret.sign(ballot_data_hash.data);
+        ballot_data.signature = temporary_key.secret.sign<boasdk.BallotData>(ballot_data);
 
         let link_data = ballot_data.getLinkData();
         let expected = {
-            payload: 'CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApLVKzYGJwEn71aHecOrjvqtUyeiz4R3m6hQlIQl4X/KE1KElZJ94ma0HFrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmAD8mGm7It8kUDVBBRffnu5KbezebT0c/zWYdVVXfJkyMMs6ArU+Q9swwlygSP/B9t37z8BPiMnjQhRjrv4pvnICZIwqO10jyG3bEibpuXFEEQOxbo3Gv9iekgN23+PHfGVWJBmKjO/hJMplu1GZdqppUmigMalvIznjbC50nT/45Aw='
+            payload: 'CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApNKyF4y6nf51jl+3MDB9uvh1VX1dC5DNQVMD/tXWuqtPa2SgawEDsGH3FrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmAAZEvcLHuXQHthAhJ9SfoFUz/klhcwHayy8FsL9nEmi1qtIerd3TUeN9UC4k8NlbP4mfACsUCiKkiEdkNxkzHwGZAfZFkfjqb2ceXB55FKB7oqwlonngH/RVojPpFZWv0pQpIk6BfFVjKhjYU/sxJrT/1MNbYHm+CmSc2xWDDAipQM='
         };
 
         let deserialized_ballot_data = boasdk.BallotData.deserialize(SmartBuffer.fromBuffer(Buffer.from(link_data.payload, "base64")));

--- a/tests/Votera.test.ts
+++ b/tests/Votera.test.ts
@@ -168,7 +168,7 @@ export class TestStoa {
                             [
                                 new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e")))
                             ],
-                            new boasdk.DataPayload(Buffer.from("CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApLVKzYGJwEn71aHecOrjvqtUyeiz4R3m6hQlIQl4X/KE1KElZJ94ma0HFrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmAD8mGm7It8kUDVBBRffnu5KbezebT0c/zWYdVVXfJkyMMs6ArU+Q9swwlygSP/B9t37z8BPiMnjQhRjrv4pvnICZIwqO10jyG3bEibpuXFEEQOxbo3Gv9iekgN23+PHfGVWJBmKjO/hJMplu1GZdqppUmigMalvIznjbC50nT/45Aw=", "base64"))
+                            new boasdk.DataPayload(Buffer.from("CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApNKyF4y6nf51jl+3MDB9uvh1VX1dC5DNQVMD/tXWuqtPa2SgawEDsGH3FrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmAAZEvcLHuXQHthAhJ9SfoFUz/klhcwHayy8FsL9nEmi1qtIerd3TUeN9UC4k8NlbP4mfACsUCiKkiEdkNxkzHwGZAfZFkfjqb2ceXB55FKB7oqwlonngH/RVojPpFZWv0pQpIk6BfFVjKhjYU/sxJrT/1MNbYHm+CmSc2xWDDAipQM=", "base64"))
                         );
                         res.status(200).send(JSON.stringify(tx));
                     }


### PR DESCRIPTION
Recently, the method of calculating the hash in Agora has been changed.
As a result, transactions are not being processed normally when they are sent from the wallet.
The newly added code included the size type of the array and the length of the array when the array was hash.
I changed the hash value calculation method to the same as Agora.