### PR TITLE
Fix: Change the order of a point and a scalar for Schnorr signature result

### DIFF
--- a/src/modules/common/Schnorr.ts
+++ b/src/modules/common/Schnorr.ts
@@ -61,12 +61,12 @@ export class Sig
     /**
      * Construct a new instance of this class
      *
-     * @param r The instance of Point
+     * @param R The instance of Point
      * @param s The instance of Scalar
      */
-    constructor (r: Point, s: Scalar)
+    constructor (R: Point, s: Scalar)
     {
-        this.R = r;
+        this.R = R;
         this.s = s;
     }
 
@@ -75,7 +75,7 @@ export class Sig
      */
     public toSignature (): Signature
     {
-        return new Signature(Buffer.concat([this.R.data, this.s.data]));
+        return new Signature(Buffer.concat([this.s.data, this.R.data]));
     }
 
     /**
@@ -83,7 +83,7 @@ export class Sig
      */
     public static fromSignature (s: Signature): Sig
     {
-        return new Sig(new Point(s.data.slice(0, Point.Width)), new Scalar(s.data.slice(Point.Width)));
+        return new Sig(new Point(s.data.slice(Scalar.Width)), new Scalar(s.data.slice(0, Scalar.Width)));
     }
 
     /**

--- a/tests/Schnorr.test.ts
+++ b/tests/Schnorr.test.ts
@@ -22,6 +22,15 @@ describe ('Test of Schnorr', () =>
         return sdk.SodiumHelper.init();
     });
 
+    it ('Create Signature', () =>
+    {
+        const signature = (new sdk.Sig(
+            new sdk.Point("0x921405afbfa97813293770efd55865c01055f39ad2a70f2b7a04ac043766a693"),
+            new sdk.Scalar("0x074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216")
+            )).toSignature();
+        assert.deepStrictEqual(signature.toString(), "0x921405afbfa97813293770efd55865c01055f39ad2a70f2b7a04ac043766a693074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216");
+    });
+
     it ('Single signature', () =>
     {
         let kp: sdk.Pair  = sdk.Pair.random();

--- a/tests/Vote.test.ts
+++ b/tests/Vote.test.ts
@@ -230,7 +230,7 @@ describe ('Vote Data', () =>
 
         let link_data = ballot_data.getLinkData();
         let expected = {
-            payload: 'CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApNKyF4y6nf51jl+3MDB9uvh1VX1dC5DNQVMD/tXWuqtPa2SgawEDsGH3FrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmAAZEvcLHuXQHthAhJ9SfoFUz/klhcwHayy8FsL9nEmi1qtIerd3TUeN9UC4k8NlbP4mfACsUCiKkiEdkNxkzHwGZAfZFkfjqb2ceXB55FKB7oqwlonngH/RVojPpFZWv0pQpIk6BfFVjKhjYU/sxJrT/1MNbYHm+CmSc2xWDDAipQM='
+            payload: 'CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApmapMXuWYfDz6vBZlmCuUM6zby7i5F5cnZcgKGdWHDcQ5RVvGl6/kxbTFrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmACYgDrsUNlQtYTrndUiTdejjcy998j5jTp0i3CIrH0dC2CeqzRrR4+UOedDv4I4ssC6Xg0p6ROTFg80fpamJbEDZDsi9IwtpwPpq9gRXxjZf7YTozv7JM9N69i4BhSa304GzQAP6uDBx9Tks3+kdFYEUG74lJ69wPJbF1edqb72bUc='
         };
 
         let deserialized_ballot_data = boasdk.BallotData.deserialize(SmartBuffer.fromBuffer(Buffer.from(link_data.payload, "base64")));

--- a/tests/Votera.test.ts
+++ b/tests/Votera.test.ts
@@ -168,7 +168,7 @@ export class TestStoa {
                             [
                                 new boasdk.TxOutput("3000000", boasdk.Lock.fromPublicKey(new boasdk.PublicKey("boa1xrw66w303s5x05ej9uu6djc54kue29j72kah22xqqcrtqj57ztwm5uh524e")))
                             ],
-                            new boasdk.DataPayload(Buffer.from("CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApNKyF4y6nf51jl+3MDB9uvh1VX1dC5DNQVMD/tXWuqtPa2SgawEDsGH3FrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmAAZEvcLHuXQHthAhJ9SfoFUz/klhcwHayy8FsL9nEmi1qtIerd3TUeN9UC4k8NlbP4mfACsUCiKkiEdkNxkzHwGZAfZFkfjqb2ceXB55FKB7oqwlonngH/RVojPpFZWv0pQpIk6BfFVjKhjYU/sxJrT/1MNbYHm+CmSc2xWDDAipQM=", "base64"))
+                            new boasdk.DataPayload(Buffer.from("CEJBTExPVCAgBlZvdGVyYQxJRDEyMzQ1Njc4OTApmapMXuWYfDz6vBZlmCuUM6zby7i5F5cnZcgKGdWHDcQ5RVvGl6/kxbTFrSKdkwbnyCSISJw+l76oyJmY8Vncx0mYjWFV1big5setAqNd51Ay94fqSlwrBuOtBR0YA2VpyRX02J3If7S4/oCWmACYgDrsUNlQtYTrndUiTdejjcy998j5jTp0i3CIrH0dC2CeqzRrR4+UOedDv4I4ssC6Xg0p6ROTFg80fpamJbEDZDsi9IwtpwPpq9gRXxjZf7YTozv7JM9N69i4BhSa304GzQAP6uDBx9Tks3+kdFYEUG74lJ69wPJbF1edqb72bUc=", "base64"))
                         );
                         res.status(200).send(JSON.stringify(tx));
                     }


### PR DESCRIPTION
I sent the transaction made using SDK to Agora.
A wrong signature message appeared.
When I look up the cause, I find that the position of the Point and Scalar included in the signature has changed and correct it to the same as Agora.
I also included a test code that existed in Agora.