### PR TITLE
Fix: JSON validator for PreImageInfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "The TypeScript BOA SDK library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/modules/data/PreImageInfo.ts
+++ b/src/modules/data/PreImageInfo.ts
@@ -68,6 +68,6 @@ export class PreImageInfo
         JSONValidator.isValidOtherwiseThrow('PreImageInfo', value);
 
         return new PreImageInfo(
-            new Hash(value.enroll_key), new Hash(value.hash), Number(value.distance));
+            new Hash(value.utxo), new Hash(value.hash), Number(value.distance));
     }
 }

--- a/src/modules/utils/JSONValidator.ts
+++ b/src/modules/utils/JSONValidator.ts
@@ -171,7 +171,7 @@ export class JSONValidator
                     }
                 },
                 "additionalProperties": false,
-                "required": ["enroll_key", "hash", "distance"]
+                "required": ["utxo", "hash", "distance"]
             }
 
         ],


### PR DESCRIPTION
I changed `enroll_key` to `utxo` in JSON validator for PreImageInfo.
And raise it to version 0.0.34 of SDK.