### PR TITLE
Add a method isValidRandomBytes in KeyPair

### DIFF
--- a/src/modules/common/ECC.ts
+++ b/src/modules/common/ECC.ts
@@ -163,8 +163,8 @@ export class Scalar
         return new Scalar(Buffer.from(SodiumHelper.sodium.crypto_core_ed25519_scalar_random()));
     }
 
-    private static ED25519_L = Buffer.from("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed", "hex").reverse();
-    private static ZERO =      Buffer.from("0000000000000000000000000000000000000000000000000000000000000000", "hex");
+    public static ED25519_L = Buffer.from("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed", "hex").reverse();
+    public static ZERO =      Buffer.from("0000000000000000000000000000000000000000000000000000000000000000", "hex");
 
     /**
      * Scalar should be greater than zero and less than L:2^252 + 27742317777372353535851937790883648493

--- a/src/modules/common/KeyPair.ts
+++ b/src/modules/common/KeyPair.ts
@@ -77,6 +77,23 @@ export class KeyPair
     }
 
     /**
+     * Checks whether a valid scalar can be created with a given random bytes
+     * @param r The random bytes
+     * @return Returns true if a valid scalar can be created with a given random bytes,
+     * otherwise false.
+     */
+    public static isValidRandomBytes (r: Buffer): boolean
+    {
+        if (r.length !== SodiumHelper.sodium.crypto_core_ed25519_SCALARBYTES)
+            return false;
+
+        let t = Buffer.from(r);
+        t[SodiumHelper.sodium.crypto_core_ed25519_SCALARBYTES - 1] &= 0x1f;
+
+        return (Utils.compareBuffer(t, Scalar.ZERO) > 0) && (Utils.compareBuffer(t, Scalar.ED25519_L) < 0);
+    }
+
+    /**
      * Signs a message with this keypair's private key
      * @param msg The message to sign.
      * @returns The signature of `msg` using `this`

--- a/tests/KeyPair.test.ts
+++ b/tests/KeyPair.test.ts
@@ -238,4 +238,14 @@ describe ('KeyPair', () =>
         assert.deepStrictEqual(random_kp.secret, reproduced_kp.secret);
         assert.deepStrictEqual(random_kp.address, reproduced_kp.address);
     });
+
+
+    it ('Test of KeyPair.isValidRandomBytes()', () =>
+    {
+        let random_bytes = Buffer.from("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed", "hex").reverse();
+        assert.ok(!boasdk.KeyPair.isValidRandomBytes(random_bytes));
+
+        random_bytes = Buffer.from("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ec", "hex").reverse();
+        assert.ok(boasdk.KeyPair.isValidRandomBytes(random_bytes));
+    })
 });


### PR DESCRIPTION
I add a method isValidRandomBytes in KeyPair

It returns true if a valid scalar can be created with given random bytes, otherwise false.