### PR TITLE
Fix a circular reference problem

### DIFF
--- a/src/modules/net/BOAClient.ts
+++ b/src/modules/net/BOAClient.ts
@@ -24,7 +24,6 @@ import { ITxHistoryElement, ITxOverview, IPendingTxs } from './response/Types';
 import { Transaction } from '../data/Transaction';
 import { handleNetworkError } from './error/ErrorTypes';
 import { TxPayloadFee } from '../utils/TxPayloadFee';
-import { BallotData } from '../vote/BallotData';
 
 import { AxiosResponse } from 'axios';
 import uri from 'urijs';

--- a/src/modules/script/Lock.ts
+++ b/src/modules/script/Lock.ts
@@ -38,7 +38,7 @@
 import { hashPart } from '../common/Hash';
 import { PublicKey } from '../common/KeyPair';
 import { Signature } from '../common/Signature';
-import { JSONValidator } from '../..';
+import { JSONValidator } from '../utils/JSONValidator';
 import { Utils } from "../utils/Utils";
 
 import { SmartBuffer } from 'smart-buffer';

--- a/src/modules/vote/ProposalFeeData.ts
+++ b/src/modules/vote/ProposalFeeData.ts
@@ -14,11 +14,11 @@
 
 import { PublicKey } from '../common/KeyPair';
 import { VarInt } from '../utils/VarInt';
+import { Utils } from "../utils/Utils";
 import { LinkDataWithProposalFee } from '../wallet/LinkData';
 
 import JSBI from 'jsbi';
 import { SmartBuffer } from 'smart-buffer';
-import {Utils} from "../..";
 
 /**
  * The class that defines data stored in the transaction's payload


### PR DESCRIPTION
React Native has issued a warning as below, so I modified it.

`[Thu Apr 29 2021 16:39:49.260]  WARN     Require cycle: node_modules/boa-sdk-ts/lib/index.js -> node_modules/boa-sdk-ts/lib/modules/data/Block.js -> node_modules/boa-sdk-ts/lib/modules/data/Transaction.js -> node_modules/boa-sdk-ts/lib/modules/data/TxInput.js -> node_modules/boa-sdk-ts/lib/modules/script/Lock.js -> node_modules/boa-sdk-ts/lib/index.js

Require cycles are allowed, but can result in uninitialized values. Consider refactoring to remove the need for a cycle.
[Thu Apr 29 2021 16:39:49.270]  WARN     Require cycle: node_modules/boa-sdk-ts/lib/index.js -> node_modules/boa-sdk-ts/lib/modules/vote/ProposalFeeData.js -> node_modules/boa-sdk-ts/lib/index.js

Require cycles are allowed, but can result in uninitialized values. Consider refactoring to remove the need for a cycle.
`