### PR TITLE
Change the expression of DataPayload from hex to base64

### DIFF
--- a/src/modules/data/DataPayload.ts
+++ b/src/modules/data/DataPayload.ts
@@ -35,7 +35,7 @@ export class DataPayload
     constructor (data: Buffer | string, endian: Endian = Endian.Big)
     {
         if (typeof data === 'string')
-            this.data = Utils.readFromString(data, undefined, endian);
+            this.data = Buffer.from(data, "base64");
         else
             this.data = this.fromBinary(data, endian).data;
     }
@@ -57,27 +57,27 @@ export class DataPayload
 
         JSONValidator.isValidOtherwiseThrow('DataPayload', value);
 
-        return new DataPayload(value);
+        return new DataPayload(value.bytes);
     }
 
     /**
-     * Reads from the hex string
-     * @param hex The hex string
+     * Reads from the base64 string
+     * @param data The base64 string
      * @returns The instance of DataPayload
      */
-    public fromString (hex: string): DataPayload
+    public fromString (data: string): DataPayload
     {
-        this.data = Utils.readFromString(hex);
+        this.data = Buffer.from(data, "base64");
         return this;
     }
 
     /**
-     * Writes to the hex string
-     * @returns The hex string
+     * Writes to the base64 string
+     * @returns The base64 string
      */
     public toString (): string
     {
-        return Utils.writeToString(this.data, Endian.Big);
+        return this.data.toString("base64");
     }
 
     /**
@@ -120,9 +120,11 @@ export class DataPayload
     /**
      * Converts this object to its JSON representation
      */
-    public toJSON (key?: string): string
+    public toJSON (key?: string): any
     {
-        return this.toString();
+        return {
+            bytes: this.data.toString("base64")
+        };
     }
 
     /**

--- a/src/modules/utils/JSONValidator.ts
+++ b/src/modules/utils/JSONValidator.ts
@@ -124,11 +124,15 @@ export class JSONValidator
             "DataPayload",
             {
                 "title": "DataPayload",
-                "type": "string",
+                "type": "object",
+                "properties": {
+                    "bytes": {
+                        "type": "string"
+                    }
+                },
                 "additionalProperties": false,
-                "required": []
+                "required": ["bytes"]
             }
-
         ],
         [
             "Enrollment",
@@ -197,7 +201,7 @@ export class JSONValidator
                         "type": "array"
                     },
                     "payload": {
-                        "type": "string"
+                        "type": "object"
                     },
                     "lock_height": {
                         "type": "string"

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -197,7 +197,7 @@ let sample_tx = {
             }
         }
     ],
-    "payload": "",
+    "payload": {"bytes": ""},
     "lock_height": "0"
 };
 
@@ -1068,7 +1068,7 @@ describe('BOA Client', () => {
         let builder = new boasdk.TxBuilder(
             boasdk.KeyPair.fromSeed(new boasdk.SecretKey("SD4IEXJ6GWZ226ALTDDM72SYMHBTTJ6CHDPUNNTVZK4XSDHAM4BAQIC4")));
 
-        let vote_data = new boasdk.DataPayload("0x617461642065746f76");
+        let vote_data = new boasdk.DataPayload("YXRhZCBldG92");
         let fee = boasdk.TxPayloadFee.getFee(vote_data.data.length);
 
         let vote_tx =
@@ -1121,7 +1121,7 @@ describe('BOA Client', () => {
                     }
                 }
             ],
-            "payload": "0x617461642065746f76",
+            "payload": {"bytes": "YXRhZCBldG92"},
             "lock_height": "0"
         };
 
@@ -1157,7 +1157,7 @@ describe('BOA Client', () => {
                 "4ec66b2d70ddf407b8196b46bc1dfe42061c7497"),
             amount : JSBI.BigInt(100000000)
         };
-        let vote_data = new boasdk.DataPayload("0x617461642065746f76");
+        let vote_data = new boasdk.DataPayload("YXRhZCBldG92");
         let fee = boasdk.TxPayloadFee.getFee(vote_data.data.length);
 
         let builder = new boasdk.TxBuilder(
@@ -1185,7 +1185,7 @@ describe('BOA Client', () => {
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
-        let vote_data = new boasdk.DataPayload("0x617461642065746f76");
+        let vote_data = new boasdk.DataPayload("YXRhZCBldG92");
         let payload_fee = boasdk.TxPayloadFee.getFee(vote_data.data.length);
         let tx_fee = JSBI.BigInt(0);
 
@@ -1232,7 +1232,7 @@ describe('BOA Client', () => {
                         }
                     }
                 ],
-                "payload": "0x617461642065746f76",
+                "payload": {"bytes": "YXRhZCBldG92"},
                 "lock_height": "0"
             };
 
@@ -1266,7 +1266,7 @@ describe('BOA Client', () => {
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
-        let vote_data = new boasdk.DataPayload("0x617461642065746f76");
+        let vote_data = new boasdk.DataPayload("YXRhZCBldG92");
         let payload_fee = JSBI.BigInt(200000);
         let tx_fee = JSBI.BigInt(0);
 
@@ -1300,7 +1300,7 @@ describe('BOA Client', () => {
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
-        let vote_data = new boasdk.DataPayload("0x617461642065746f76");
+        let vote_data = new boasdk.DataPayload("YXRhZCBldG92");
         let payload_fee = JSBI.BigInt(200000);
         let tx_fee = JSBI.BigInt(0);
 
@@ -1345,7 +1345,7 @@ describe('BOA Client', () => {
                         }
                     }
                 ],
-                "payload": "0x617461642065746f76",
+                "payload": {"bytes": "YXRhZCBldG92"},
                 "lock_height": "0"
             };
 
@@ -1404,7 +1404,7 @@ describe('BOA Client', () => {
         let block_height = await boa_client.getBlockHeight();
         let utxos = await boa_client.getUTXOs(key_pair.address);
 
-        let vote_data = new boasdk.DataPayload("0x617461642065746f76");
+        let vote_data = new boasdk.DataPayload("YXRhZCBldG92");
         let payload_fee = boasdk.TxPayloadFee.getFee(vote_data.data.length);
 
         let builder = new boasdk.TxBuilder(key_pair);
@@ -1487,35 +1487,35 @@ describe('BOA Client', () => {
                 {
                     "utxo": "0x3451d94322524e3923fd26f0597fb8a9cdbf3a9427c38ed1ca61104796d39c5b9b5ea33d576f17c2dc17bebc5d84a0559de8c8c521dfe725d4c352255fc71e85",
                     "unlock": {
-                        "bytes": "4qgxRsfgLCaBKDVw9KJM/BfKb8tJX41s8WgxcNCAUq83APZtIxyVYs2Te//osUEAFhcpTSagF1zglG/myF4+Bg=="
+                        "bytes": "jKVq2VTBXnfyyEuLT7cvYdGM2NAyNC+zlmIh0UFdrwvAie7Ij343BgsC+86wWOZlc3QqUegTYkjRg4NkjiV5og=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0xfca92fe76629311c6208a49e89cb26f5260777278cd8b272e7bb3021adf429957fd6844eb3b8ff64a1f6074126163fd636877fa92a1f4329c5116873161fbaf8",
                     "unlock": {
-                        "bytes": "mqMB1bLL0PXTEB80TuMh5mBPllHNW/EF1EkAyE8lQbIOFhr44s3wCpS5unUdDPeDgZoMOzuqFc7S7OTkG/hUDg=="
+                        "bytes": "sriR4UDqSQJhiYz1ar8qpdX3WJ2dRzxJ9m3MY+7NuwH9bF2SGGpvF+GhuwITXNuA9IKJ2ChzOFcEnCaHkuEcRw=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0x7e1958dbe6839d8520d65013bbc85d36d47a9f64cf608cc66c0d816f0b45f5c8a85a8990725ffbb1ab13c3c65b45fdc06f4745d455e00e1068c4c5c0b661d685",
                     "unlock": {
-                        "bytes": "0hwN3QwAtBXXNrd6YwP5CNLZcKsr+1SkARXwqNCiHeBgRqzELLoVpOEVuTGfEh7fmnsb8zUc2qfSybH75T78Cg=="
+                        "bytes": "AT0s1ZkCPnuFRaoLK8mH303uO/23WbBwYo6jnhzRAgAqD15TOuVNYhwf/Ah8ulmQ3LimvKqPVfDZi3J6dqUvgA=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0xd44608de8a5015b04f933098fd7f67f84ffbf00c678836d38c661ab6dc1f149606bdc96bad149375e16dc5722b077b14c0a4afdbe6d30932f783650f435bcb92",
                     "unlock": {
-                        "bytes": "61WpwyBIJeYArr26pv2S1QhxTiraQwvt+Gn9xWFhge11uZ2tQYu3eiw8UZ4KRKmQGlymRqfpY+bKwIJDJKVQDQ=="
+                        "bytes": "gfoyNGdkhlHuPLLNMS2ABrGeWmuItR83MsDCbCO35AAusghrY1xeu3/rLe0nDOi9Yaj8bsZ42uJONJPQgEJPtg=="
                     },
                     "unlock_age": 0
                 },
                 {
                     "utxo": "0xc3780f9907a97c20a2955945544e7732a60702c32d81e016bdf1ea172b7b7fb96e9a4164176663a146615307aaadfbbad77e615a7c792a89191e85471120d314",
                     "unlock": {
-                        "bytes": "csSLViq4Dz7pc01erw3vkBHQObfJSiFtxSBgoAiitHy31NrZaeArFYEZle7oDDvH8J+RrRXgI4bKRSRap5axCQ=="
+                        "bytes": "MqXWkwsgyOxtf/n6ZTp5Z0/Um8qhYZ4DV/hza03IIgLvqQEw7smrEK+oLEIE5OqOWhOrb53BkSQxfHpxZNoXZg=="
                     },
                     "unlock_age": 0
                 }
@@ -1536,7 +1536,7 @@ describe('BOA Client', () => {
                     }
                 }
             ],
-            "payload": "0x617461642065746f76",
+            "payload": {"bytes": "YXRhZCBldG92"},
             "lock_height": "0"
         };
 

--- a/tests/TxBuilder.test.ts
+++ b/tests/TxBuilder.test.ts
@@ -115,7 +115,7 @@ describe ('TxBuilder', () =>
                     }
                 }
             ],
-            "payload": "",
+            "payload": {"bytes": ""},
             "lock_height": "0"
         };
 
@@ -133,7 +133,7 @@ describe ('TxBuilder', () =>
     {
         let builder = new boasdk.TxBuilder(owner);
         let tx: boasdk.Transaction;
-        let payload = new boasdk.DataPayload("0x617461642065746f76");
+        let payload = new boasdk.DataPayload("YXRhZCBldG92");
         let payload_fee = JSBI.BigInt(500000);
         let tx_fee = JSBI.BigInt(0);
 
@@ -176,7 +176,7 @@ describe ('TxBuilder', () =>
                     }
                 }
             ],
-            "payload": "0x617461642065746f76",
+            "payload": {"bytes": "YXRhZCBldG92"},
             "lock_height": "0"
         };
 

--- a/tests/ValidationJSON.test.ts
+++ b/tests/ValidationJSON.test.ts
@@ -27,7 +27,7 @@ describe ('Test that validation with JSON schema', () =>
             ("Transaction", {
                 "inputs": [],
                 "outputs": [],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             });
         }, new Error("Validation failed: Transaction" +
@@ -41,7 +41,7 @@ describe ('Test that validation with JSON schema', () =>
                 "type": 1,
                 "inputs": {},
                 "outputs": [],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             });
         }, new Error("Validation failed: Transaction - should be array"));
@@ -51,7 +51,7 @@ describe ('Test that validation with JSON schema', () =>
         ("Transaction", {
             "inputs": [],
             "outputs": [],
-            "payload": "",
+            "payload": {"bytes": ""},
             "lock_height": "0"
         }));
 
@@ -61,7 +61,7 @@ describe ('Test that validation with JSON schema', () =>
             "type": 1,
             "inputs": {},
             "outputs": [],
-            "payload": "",
+            "payload": {"bytes": ""},
             "lock_height": "0"
         }));
 
@@ -77,7 +77,7 @@ describe ('Test that validation with JSON schema', () =>
                     "lock": {"type": 0, "bytes": "KkpengSTntVIh037afPquSSwuq/KlbhEr/ydUPM4no4="}
                 }
             ],
-            "payload": "",
+            "payload": {"bytes": ""},
             "lock_height": "0"
         }));
 
@@ -102,7 +102,7 @@ describe ('Test that validation with JSON schema', () =>
                     }
                 }
             ],
-            "payload": "",
+            "payload": {"bytes": ""},
             "lock_height": "0"
         }));
 
@@ -182,9 +182,9 @@ describe ('Test that JSON.stringify of Transaction', () =>
                     new boasdk.PublicKey("boa1xrgr66gdm5je646x70l5ar6qkhun0hg3yy2eh7tf8xxlmlt9fgjd2q0uj8p")
                 )
             ],
-            new boasdk.DataPayload("0x0001")
+            new boasdk.DataPayload("YXRhZCBldG92")
         )
         assert.strictEqual(JSON.stringify(tx),
-            `{"type":0,"inputs":[{"utxo":"0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32","unlock":{"bytes":"vaX+wxScBr2KIsPgKzku9kkGrfuQI8ar1eXWn9LoHxfWrLOmnliHjkGOGWk+QJ7urnpz9lRENrCMv9gsQZ4DCQ=="},"unlock_age":0}],"outputs":[{"value":"1663400000","lock":{"type":0,"bytes":"xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM="}},{"value":"24398336600000","lock":{"type":0,"bytes":"0D1pDd0lnVdG8/9Oj0C1+TfdESEVm/lpOY39/WVKJNU="}}],"payload":"0x0001","lock_height":"0"}`);
+            `{"type":0,"inputs":[{"utxo":"0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32","unlock":{"bytes":"vaX+wxScBr2KIsPgKzku9kkGrfuQI8ar1eXWn9LoHxfWrLOmnliHjkGOGWk+QJ7urnpz9lRENrCMv9gsQZ4DCQ=="},"unlock_age":0}],"outputs":[{"value":"1663400000","lock":{"type":0,"bytes":"xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM="}},{"value":"24398336600000","lock":{"type":0,"bytes":"0D1pDd0lnVdG8/9Oj0C1+TfdESEVm/lpOY39/WVKJNU="}}],"payload":{"bytes":"YXRhZCBldG92"},"lock_height":"0"}`);
     });
 });

--- a/tests/data/Blocks.sample3.json
+++ b/tests/data/Blocks.sample3.json
@@ -96,7 +96,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -160,7 +160,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             }
         ],
@@ -371,7 +371,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -562,7 +562,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -753,7 +753,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -944,7 +944,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -1135,7 +1135,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -1326,7 +1326,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -1517,7 +1517,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             },
             {
@@ -1708,7 +1708,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             }
         ],
@@ -1770,7 +1770,7 @@
                         }
                     }
                 ],
-                "payload": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+                "payload": {"bytes": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/wABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX5/gIGCg4SFhoeIiYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6ipqqusra6vsLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8AAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr/AwcLDxMXGx8jJysvMzc7P0NHS09TV1tfY2drb3N3e3+Dh4uPk5ebn6Onq6+zt7u/w8fLz9PX29/j5+vv8/f7/AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=="},
                 "lock_height": "0"
             },
             {
@@ -1821,7 +1821,7 @@
                         }
                     }
                 ],
-                "payload": "",
+                "payload": {"bytes": ""},
                 "lock_height": "0"
             }
         ],


### PR DESCRIPTION
When DataPayload is serialized to JSON, change what is represented as hex string to Base64 expression.
This has been changed consistently with other types (Unlock, Lock, etc.).

Related to https://github.com/bosagora/stoa/issues/268