### PR TITLE
Export the data types needed for linking with the wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "The TypeScript BOA SDK library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export { ProposalFeeData } from './modules/vote/ProposalFeeData';
 export { ProposalType, ProposalData } from './modules/vote/ProposalData';
 export { VoterCard, BallotData } from './modules/vote/BallotData';
 export { Encrypt } from './modules/vote/Encrypt';
+export { LinkDataWithProposalFee, LinkDataWithProposalData, LinkDataWithVoteData } from './modules/wallet/LinkData';
 
 export { LockType, Lock, Unlock } from './modules/script/Lock';
 export { OP, isOpcode, isConditional, isPayload } from './modules/script/Opcodes';


### PR DESCRIPTION
Some of the data types used in the Votera App have not been exported.