### PR TITLE
Implementing the ability to create a cancellation transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "The TypeScript BOA SDK library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export { checksum, validate } from './modules/utils/CRC16';
 export { TxPayloadFee } from './modules/utils/TxPayloadFee';
 export { UTXOManager } from './modules/utils/UTXOManager';
 export { TxBuilder, RawInput } from './modules/utils/TxBuilder';
+export { TxCanceller, TxCancelResultCode, ITxCancelResult } from './modules/utils/TxCanceller';
 export { VarInt } from './modules/utils/VarInt';
 
 export { JSONValidator } from './modules/utils/JSONValidator';

--- a/src/modules/net/BOAClient.ts
+++ b/src/modules/net/BOAClient.ts
@@ -292,6 +292,39 @@ export class BOAClient
     }
 
     /**
+     * Request UTXO's information about the UTXO hash array.
+     * @param hashes The hash of UTXOs
+     * @returns Promise that resolves or
+     * rejects with response from the Stoa
+     */
+    public getUTXOInfo (hashes: Array<Hash>): Promise<Array<UnspentTxOutput>>
+    {
+        return new Promise<Array<UnspentTxOutput>>((resolve, reject) =>
+        {
+            let url = uri(this.server_url)
+                .directory("utxos");
+
+            let utxo_hashes = hashes.map(m => m.toString());
+            Request.post(url.toString(), {utxos: utxo_hashes})
+                .then((response: AxiosResponse) =>
+                {
+                    let utxos: Array<UnspentTxOutput> = new Array<UnspentTxOutput>();
+                    response.data.forEach((elem: any) =>
+                    {
+                        let utxo = new UnspentTxOutput();
+                        utxo.fromJSON(elem);
+                        utxos.push(utxo);
+                    });
+                    resolve(utxos);
+                })
+                .catch((reason: any) =>
+                {
+                    reject(handleNetworkError(reason));
+                });
+        });
+    }
+
+    /**
      * Request an Stoa's current block height.
      */
     public getBlockHeight (): Promise<JSBI>

--- a/src/modules/net/response/UnspentTxOutput.ts
+++ b/src/modules/net/response/UnspentTxOutput.ts
@@ -53,6 +53,16 @@ export class UnspentTxOutput
     time: number;
 
     /**
+     * The lock type
+     */
+    lock_type: number;
+
+    /**
+     * The lock bytes
+     */
+    lock_bytes: string;
+
+    /**
      * Constructor
      * @param utxo          The hash of the UTXO key
      * @param type          The type of the transaction output
@@ -60,9 +70,11 @@ export class UnspentTxOutput
      * @param amount        The amount value of this utxo, in 1/10^7
      * @param height        The height of the block on created
      * @param time          The time of the block on created
+     * @param lock_type     The lock type
+     * @param lock_bytes    The lock bytes
      */
     constructor (utxo?: Hash, type?: OutputType, unlock_height?: JSBI, amount?: JSBI,
-                 height?: JSBI, time?: number)
+                 height?: JSBI, time?: number, lock_type?: number, lock_bytes?: string)
     {
         if (utxo != undefined)
             this.utxo = new Hash(utxo.data);
@@ -93,6 +105,16 @@ export class UnspentTxOutput
             this.time = time;
         else
             this.time = 0;
+
+        if (lock_type != undefined)
+            this.lock_type = lock_type;
+        else
+            this.lock_type = 0;
+
+        if (lock_bytes != undefined)
+            this.lock_bytes = lock_bytes;
+        else
+            this.lock_bytes = "";
     }
 
     /**
@@ -109,6 +131,8 @@ export class UnspentTxOutput
         this.amount = JSBI.BigInt(data.amount);
         this.height = JSBI.BigInt(data.height);
         this.time = data.time;
+        this.lock_type = data.lock_type;
+        this.lock_bytes = data.lock_bytes;
     }
 }
 
@@ -124,4 +148,6 @@ export interface JSONUnspentTxOutput
     amount: string;
     height: string;
     time: number;
+    lock_type: number;
+    lock_bytes: string;
 }

--- a/src/modules/utils/TxCanceller.ts
+++ b/src/modules/utils/TxCanceller.ts
@@ -1,0 +1,268 @@
+/*******************************************************************************
+
+    Includes class to cancel a transaction
+
+    Copyright:
+        Copyright (c) 2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import { Hash } from '../common/Hash';
+import { KeyPair, PublicKey } from '../common/KeyPair';
+import { Transaction } from '../data/Transaction';
+import { OutputType } from '../data/TxOutput';
+import { LockType } from '../script/Lock'
+import { UnspentTxOutput } from '../net/response/UnspentTxOutput';
+import { TxPayloadFee } from './TxPayloadFee';
+import { TxBuilder } from "./TxBuilder";
+
+import JSBI from "jsbi";
+
+/**
+ * A class that creates a cancellation transaction.
+ */
+export class TxCanceller
+{
+    public static double_spent_threshold_pct: number = 20;
+
+    /**
+     * The original transaction
+     */
+    private tx: Transaction;
+
+    /**
+     * The array of KeyPairs to be used for signing
+     */
+    private key_pairs: Array<KeyPair>;
+
+    /**
+     * The array of UTXO information used in tx's inputs
+     */
+    private utxos: Array<UnspentTxOutput>;
+
+    /**
+     * Constructor
+     * @param tx           The original transaction
+     * @param key_pairs    The array of KeyPairs to be used for signing
+     * @param utxos        The array of UTXO information used in tx's inputs
+     */
+    constructor (tx: Transaction, utxos: Array<UnspentTxOutput>, key_pairs: Array<KeyPair>)
+    {
+        this.tx = tx;
+        this.utxos = utxos;
+        this.key_pairs = key_pairs;
+    }
+
+    /**
+     * Find the element in the array that corresponds to the hash of utxo.
+     * @param utxo The hash of UTXO
+     */
+    private findUTXO (utxo: Hash): UnspentTxOutput | undefined
+    {
+        return this.utxos.find(m => Buffer.compare(m.utxo.data, utxo.data) === 0);
+    }
+
+    /**
+     * Find the element corresponding to the public key in the array.
+     * @param address The public key
+     */
+    private findKey (address: PublicKey): KeyPair | undefined
+    {
+        return this.key_pairs.find(m => Buffer.compare(m.address.data, address.data) === 0);
+    }
+
+    /**
+     * Validate that the transaction is cancelable transaction.
+     */
+    private validate (): TxCancelResultCode
+    {
+        if (this.tx.inputs.length === 0)
+            return TxCancelResultCode.InvalidTransaction;
+
+        if (this.key_pairs.length === 0)
+            return TxCancelResultCode.NotFoundKey;
+
+        for (let input of this.tx.inputs)
+        {
+            let u = this.findUTXO(input.utxo);
+            if (u === undefined)
+                return TxCancelResultCode.NotFoundUTXO;
+
+            if (u.lock_type !== LockType.Key)
+                return TxCancelResultCode.UnsupportedLockType;
+
+            let pk = new PublicKey(Buffer.from(u.lock_bytes, "base64"));
+            let found = this.findKey(pk);
+            if (found === undefined)
+                return TxCancelResultCode.NotFoundKey;
+
+            // Unfreezing transactions cannot be canceled.
+            if (u.type === OutputType.Freeze)
+                return TxCancelResultCode.UnsupportedUnfreezing;
+        }
+
+        let amount_info = this.calculateAmount();
+        let new_adjusted_fee = this.getNewAdjustedFee(amount_info);
+        let tx_size = Transaction.getEstimatedNumberOfBytes(this.tx.inputs.length,
+            this.tx.inputs.length, this.tx.payload.length);
+        let total_fee = JSBI.multiply(new_adjusted_fee, JSBI.BigInt(tx_size));
+
+        // Fees for cancellation transactions can be set larger than existing fees.
+        // Make sure it's big enough to work it out.
+        if (JSBI.lessThan(amount_info.sum_input, JSBI.add(total_fee, JSBI.BigInt(this.tx.inputs.length))))
+            return TxCancelResultCode.NotEnoughFee;
+
+        return TxCancelResultCode.Success;
+    }
+
+    /**
+     * Calculate the transaction fee.
+     */
+    private calculateAmount (): ITxAmountInfo
+    {
+        let sum_in: JSBI = JSBI.BigInt(0);
+        let sum_out: JSBI = JSBI.BigInt(0);
+
+        for (let input of this.tx.inputs)
+        {
+            let u = this.findUTXO(input.utxo);
+            if (u !== undefined)
+                sum_in = JSBI.add(sum_in, u.amount);
+        }
+
+        for (let output of this.tx.outputs)
+            sum_out = JSBI.add(sum_out, output.value);
+
+        let total_fee = JSBI.subtract(sum_in, sum_out);
+        let payload_fee = TxPayloadFee.getFee(this.tx.payload.length);
+        let tx_fee = JSBI.subtract(total_fee, payload_fee);
+        let tx_size = this.tx.getNumberOfBytes();
+
+        return {
+            sum_input: sum_in,
+            sum_output: sum_out,
+            total_fee: total_fee,
+            payload_fee: payload_fee,
+            tx_fee: tx_fee,
+            tx_size: tx_size,
+            adjusted_fee: JSBI.divide(total_fee, JSBI.BigInt(tx_size))
+        }
+    }
+
+    /**
+     * Calculate the fees to be used in cancellation transactions.
+     */
+    private getNewAdjustedFee (amount_info: ITxAmountInfo): JSBI
+    {
+        return JSBI.divide(
+            JSBI.multiply(
+                amount_info.adjusted_fee,
+                JSBI.add(
+                    JSBI.BigInt(100),
+                    JSBI.BigInt(TxCanceller.double_spent_threshold_pct)
+                )
+            ),
+            JSBI.BigInt(100)
+        );
+    }
+
+    /**
+     * Builder a cancellation transaction.
+     * @return If successful, res.code will have TxCancelResultCode.Success.
+     * Otherwise, they have values based on the cause of the error.
+     */
+    public build (): ITxCancelResult
+    {
+        let result_code = this.validate();
+        if (result_code !== TxCancelResultCode.Success)
+            return { code: result_code }
+
+        let amount_info = this.calculateAmount();
+        let new_adjusted_fee = this.getNewAdjustedFee(amount_info);
+
+        let in_length = this.tx.inputs.length;
+        let tx_size = Transaction.getEstimatedNumberOfBytes(in_length, in_length, this.tx.payload.length);
+        let total_fee = JSBI.multiply(new_adjusted_fee, JSBI.BigInt(tx_size));
+        let payload_fee = TxPayloadFee.getFee(this.tx.payload.length);
+        let tx_fee = JSBI.subtract(total_fee, payload_fee);
+
+        let divided_fee = JSBI.divide(total_fee, JSBI.BigInt(in_length));
+        let remain_fee = JSBI.subtract(total_fee,
+            JSBI.multiply(divided_fee, JSBI.BigInt(in_length)));
+
+        let builder = new TxBuilder(this.key_pairs[0]);
+
+        this.tx.inputs.forEach((input, idx) =>
+        {
+            let u = this.findUTXO(input.utxo);
+            if (u !== undefined)
+            {
+                let k = this.findKey(new PublicKey(Buffer.from(u.lock_bytes, "base64")));
+                if (k !== undefined)
+                {
+                    let amount = JSBI.subtract(u.amount, divided_fee);
+                    if (idx == in_length - 1)
+                        amount = JSBI.subtract(amount, remain_fee);
+
+                    builder.addInput(u.utxo, u.amount, k.secret);
+                    builder.addOutput(k.address, amount);
+                }
+            }
+        });
+
+        return {
+            code: result_code,
+            tx : builder.sign(OutputType.Payment, tx_fee, payload_fee,
+                    this.tx.lock_height, this.tx.inputs[0].unlock_age)
+        };
+    }
+
+    /**
+     * PublicKey extract stored on the map of UTXO
+     * @param utxo_map the map of UTXO
+     */
+    public static addresses (utxo_map: Map<string, UnspentTxOutput>): Array<PublicKey>
+    {
+        let res = new Array<PublicKey>();
+        utxo_map.forEach((value) =>
+        {
+            if (value.lock_type === LockType.Key)
+            {
+                res.push(new PublicKey(Buffer.from(value.lock_bytes, "base64")));
+            }
+        });
+        return res;
+    }
+}
+
+interface ITxAmountInfo
+{
+    sum_input: JSBI;
+    sum_output: JSBI;
+    total_fee: JSBI;
+    payload_fee: JSBI;
+    tx_fee: JSBI;
+    tx_size: number;
+    adjusted_fee: JSBI;
+}
+
+export enum TxCancelResultCode
+{
+    Success,
+    InvalidTransaction,
+    UnsupportedUnfreezing,
+    NotFoundUTXO,
+    UnsupportedLockType,
+    NotFoundKey,
+    NotEnoughFee,
+}
+
+export interface ITxCancelResult
+{
+    code: TxCancelResultCode;
+    tx?: Transaction;
+}

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -71,7 +71,9 @@ let sample_utxo =
             "height": "0",
             "time": 1577836800000,
             "unlock_height": "1",
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0x3451d94322524e3923fd26f0597fb8a9cdbf3a9427c38ed1ca61104796d39c5b9b5ea33d576f17c2dc17bebc5d84a0559de8c8c521dfe725d4c352255fc71e85",
@@ -79,7 +81,9 @@ let sample_utxo =
             "height": "1",
             "time": 1577837400000,
             "unlock_height": "2",
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0xfca92fe76629311c6208a49e89cb26f5260777278cd8b272e7bb3021adf429957fd6844eb3b8ff64a1f6074126163fd636877fa92a1f4329c5116873161fbaf8",
@@ -87,7 +91,9 @@ let sample_utxo =
             "height": "2",
             "time": 1577838000000,
             "unlock_height": "3",
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0x7e1958dbe6839d8520d65013bbc85d36d47a9f64cf608cc66c0d816f0b45f5c8a85a8990725ffbb1ab13c3c65b45fdc06f4745d455e00e1068c4c5c0b661d685",
@@ -95,7 +101,9 @@ let sample_utxo =
             "height": "3",
             "time": 1577838600000,
             "unlock_height": "4",
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0xd44608de8a5015b04f933098fd7f67f84ffbf00c678836d38c661ab6dc1f149606bdc96bad149375e16dc5722b077b14c0a4afdbe6d30932f783650f435bcb92",
@@ -104,7 +112,9 @@ let sample_utxo =
             "time": 1577839200000,
             "unlock_height": "5",
             "unlock_time": 1577836800000,
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0xc3780f9907a97c20a2955945544e7732a60702c32d81e016bdf1ea172b7b7fb96e9a4164176663a146615307aaadfbbad77e615a7c792a89191e85471120d314",
@@ -112,7 +122,9 @@ let sample_utxo =
             "height": "5",
             "time": 1577839800000,
             "unlock_height": "6",
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0x451a5b7929615121e0f2be759222853ea3acb45c94430a03de29a47db7c70e04eb4fce5b4a0c5af01d98331732546fede05fdfaf6ab429b3960aad6a20bbf0eb",
@@ -120,7 +132,9 @@ let sample_utxo =
             "height": "6",
             "time": 1577840400000,
             "unlock_height": "7",
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0xff05579da497ac482ccd2be1851e9ff1196314e97228a1fca62e6292b5e7ea91cadca41d6afe2d57048bf594c6dd73ab1f93e96717c73c128807905e7175beeb",
@@ -129,7 +143,9 @@ let sample_utxo =
             "time": 1577841000000,
             "unlock_height": "8",
             "unlock_time": 1577836800000,
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0xcfa89b7a9cd48fddc16cdcbbf0ffa7a9fd14d89c96bc3da0151db0bd7e453fe031f8a1e4d575a299c16942d9c96fbafff2497332bc48532aa7e0acf6122be0e2",
@@ -137,7 +153,9 @@ let sample_utxo =
             "height": "8",
             "time": 1577841600000,
             "unlock_height": "9",
-            "amount": "200000"
+            "amount": "200000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         },
         {
             "utxo": "0x37e17420b4bfd8be693475fbbe8b53bb80904dd3e45f3080c0d0b912b004324a27693559d884b943830f6a21b05c69061f453e8b9f03d56f3b6fd5b0c6fc2f8b",
@@ -145,7 +163,9 @@ let sample_utxo =
             "height": "9",
             "time": 1577842200000,
             "unlock_height": "10",
-            "amount": "100000"
+            "amount": "100000",
+            "lock_type": 0,
+            "lock_bytes": "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE="
         }
     ];
 
@@ -641,6 +661,35 @@ export class TestStoa {
                 }
 
                 res.status(200).send(JSON.stringify(sample_spv));
+            });
+
+        this.app.post("/utxos",
+            (req: express.Request, res: express.Response) =>
+            {
+                let result =
+                [
+                    {
+                        "utxo": "0x6fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673",
+                        "type": 0,
+                        "unlock_height": "2",
+                        "amount": "20000000000000",
+                        "height": "1",
+                        "time": 1609459200,
+                        "lock_type": 0,
+                        "lock_bytes": "uvf5H/3E3rpj8r12wjpHMPSOcoAhhCa2ecQMw6HCI84="
+                    },
+                    {
+                        "utxo": "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfced6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad",
+                        "type": 0,
+                        "unlock_height": "2",
+                        "amount": "20000000000000",
+                        "height": "1",
+                        "time": 1609459800,
+                        "lock_type": 0,
+                        "lock_bytes": "8Pfbo1EB2MhMyXG64ZzvTt50VuOGRGwIDjiXoA5xyZ8="
+                    }
+                ];
+                res.status(200).send(JSON.stringify(result));
             });
 
         this.app.set('port', this.port);
@@ -1666,5 +1715,23 @@ describe('BOA Client', () => {
             message: "Success"
         }
         assert.deepStrictEqual(status, expected);
+    });
+
+    it ('Test a function of the BOA Client - `getUTXOInfo`', async () =>
+    {
+        // Set URL
+        let stoa_uri = URI("http://localhost").port(stoa_port);
+        let agora_uri = URI("http://localhost").port(agora_port);
+
+        // Create BOA Client
+        let boa_client = new boasdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
+
+        let utxo_hash = [
+            new boasdk.Hash("0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfced6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad"),
+            new boasdk.Hash("0x6fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673"),
+            new boasdk.Hash("0x7fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673")
+        ];
+        let utxos = await boa_client.getUTXOInfo(utxo_hash);
+        assert.strictEqual(JSON.stringify(utxos), '[{"utxo":"0x6fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673","type":0,"unlock_height":[2],"amount":[-1662697472,4656],"height":[1],"time":1609459200,"lock_type":0,"lock_bytes":"uvf5H/3E3rpj8r12wjpHMPSOcoAhhCa2ecQMw6HCI84="},{"utxo":"0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfced6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad","type":0,"unlock_height":[2],"amount":[-1662697472,4656],"height":[1],"time":1609459800,"lock_type":0,"lock_bytes":"8Pfbo1EB2MhMyXG64ZzvTt50VuOGRGwIDjiXoA5xyZ8="}]');
     });
 });

--- a/tests/TxCanceller.test.ts
+++ b/tests/TxCanceller.test.ts
@@ -1,0 +1,274 @@
+/*******************************************************************************
+
+    Test for TxCanceller
+
+    Copyright:
+        Copyright (c) 2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import * as sdk from '../lib';
+import { BOASodium } from "boa-sodium-ts";
+
+import * as assert from 'assert';
+
+describe ('TxCanceller', () =>
+{
+    let key_pairs: Array<sdk.KeyPair>;
+    let utxo_array: Array<any>;
+
+    function makeOriginalTransaction (owner_keypair: sdk.KeyPair, in_amount: sdk.JSBI, out_amount: sdk.JSBI): sdk.Transaction
+    {
+        let builder = new sdk.TxBuilder(owner_keypair);
+
+        let output_address = "boa1xqd00qsu7n5ykyckc23wmcjglfalcdea3x2af88hx2x5qx65x7w8g2r5t29";
+        let input_count = 2;
+        let output_count = 2;
+        let tx_size = sdk.Transaction.getEstimatedNumberOfBytes(input_count, output_count, 0);
+        let tx_fee = sdk.JSBI.BigInt(sdk.Utils.FEE_FACTOR * tx_size);
+        let minimum = sdk.JSBI.BigInt(100_000);
+        if (sdk.JSBI.lessThan(tx_fee, minimum))
+            tx_fee = sdk.JSBI.BigInt(minimum);
+
+        builder.addInput(
+            new sdk.Hash(
+                "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfce" +
+                "d6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad"),
+            in_amount);
+        builder.addInput(
+            new sdk.Hash(
+                "0x6fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83" +
+                "cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673"),
+            in_amount);
+
+        // Build a transaction
+        return builder
+            .addOutput(new sdk.PublicKey(output_address), out_amount)
+            .sign(sdk.OutputType.Payment, tx_fee);
+    }
+
+    before ('Wait for the package libsodium to finish loading', () =>
+    {
+        sdk.SodiumHelper.assign(new BOASodium());
+        return sdk.SodiumHelper.init();
+    });
+
+    before('Prepare variables', () =>
+    {
+        key_pairs = [
+            sdk.KeyPair.fromSeed(new sdk.SecretKey("SAFRBTFVAB37EEJDIUGCDK5R3KSL3QDBO3SPS6GX752IILWB4NGQY7KJ")),
+            sdk.KeyPair.fromSeed(new sdk.SecretKey("SCX34MSZILQJT42XRSOEOZLI7NYFB67HTCCFWPIVEGRPIUY7GW2Q4CDJ"))
+        ];
+
+        utxo_array = [
+            {
+                "utxo": "0x6fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673",
+                "type": sdk.OutputType.Payment,
+                "unlock_height": "2",
+                "amount": "20000000000000",
+                "height": "1",
+                "time": 1609459200,
+                "lock_type": 0,
+                "lock_bytes": "uvf5H/3E3rpj8r12wjpHMPSOcoAhhCa2ecQMw6HCI84="
+            },
+            {
+                "utxo": "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfced6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad",
+                "type": sdk.OutputType.Payment,
+                "unlock_height": "2",
+                "amount": "20000000000000",
+                "height": "1",
+                "time": 1609459800,
+                "lock_type": 0,
+                "lock_bytes": "8Pfbo1EB2MhMyXG64ZzvTt50VuOGRGwIDjiXoA5xyZ8="
+            }
+        ];
+    });
+
+    it ("Can not cancel a frozen transaction", () =>
+    {
+        let utxo_data = JSON.parse(JSON.stringify(utxo_array));
+        // change transaction output type
+        utxo_data[0].type = sdk.OutputType.Freeze;
+        const utxos = utxo_data.map((m: any) => {
+            let utxo = new sdk.UnspentTxOutput();
+            utxo.fromJSON(m);
+            return utxo;
+        });
+
+        const tx = makeOriginalTransaction(key_pairs[0], sdk.JSBI.BigInt("20000000000000"), sdk.JSBI.BigInt("30000000000000"));
+        const canceller = new sdk.TxCanceller(tx, utxos, key_pairs);
+        const res = canceller.build();
+        assert.strictEqual(res.code, sdk.TxCancelResultCode.UnsupportedUnfreezing);
+        assert.ok(res.tx === undefined);
+    });
+
+    it ("Transactions that do not exist UTXO cannot be canceled.", () =>
+    {
+        let utxo_data = JSON.parse(JSON.stringify(utxo_array));
+        // remove one utxo
+        utxo_data.pop();
+        const utxos = utxo_data.map((m: any) => {
+            let utxo = new sdk.UnspentTxOutput();
+            utxo.fromJSON(m);
+            return utxo;
+        });
+
+        const tx = makeOriginalTransaction(key_pairs[0], sdk.JSBI.BigInt("20000000000000"), sdk.JSBI.BigInt("30000000000000"));
+        const canceller = new sdk.TxCanceller(tx, utxos, key_pairs);
+        const res = canceller.build();
+        assert.strictEqual(res.code, sdk.TxCancelResultCode.NotFoundUTXO);
+        assert.ok(res.tx === undefined);
+    });
+
+    it ("Transactions with UTXO that `LockType` is not `Key` cannot be cancelled.", () =>
+    {
+        let utxo_data = JSON.parse(JSON.stringify(utxo_array));
+        // change a lock type
+        utxo_data[0].lock_type = sdk.LockType.KeyHash;
+        const utxos = utxo_data.map((m: any) => {
+            let utxo = new sdk.UnspentTxOutput();
+            utxo.fromJSON(m);
+            return utxo;
+        });
+
+        const tx = makeOriginalTransaction(key_pairs[0], sdk.JSBI.BigInt("20000000000000"), sdk.JSBI.BigInt("30000000000000"));
+        const canceller = new sdk.TxCanceller(tx, utxos, key_pairs);
+        const res = canceller.build();
+        assert.strictEqual(res.code, sdk.TxCancelResultCode.UnsupportedLockType);
+        assert.ok(res.tx === undefined);
+    });
+
+    it ("Transactions cannot be canceled without a KeyPair to use UTXO.", () =>
+    {
+        let utxo_data = JSON.parse(JSON.stringify(utxo_array));
+        const utxos = utxo_data.map((m: any) => {
+            let utxo = new sdk.UnspentTxOutput();
+            utxo.fromJSON(m);
+            return utxo;
+        });
+
+        // remove a keypair
+        let keys = key_pairs.slice();
+        keys.pop();
+
+        const tx = makeOriginalTransaction(key_pairs[0], sdk.JSBI.BigInt("20000000000000"), sdk.JSBI.BigInt("30000000000000"));
+        const canceller = new sdk.TxCanceller(tx, utxos, keys);
+        const res = canceller.build();
+        assert.strictEqual(res.code, sdk.TxCancelResultCode.NotFoundKey);
+        assert.ok(res.tx === undefined);
+    });
+
+    it ("Transactions with amounts of UTXO that are not large enough cannot be cancelled.", () =>
+    {
+        let utxo_data = JSON.parse(JSON.stringify(utxo_array));
+        // change amount
+        utxo_data[0].amount = "52000";
+        utxo_data[1].amount = "52000";
+        const utxos = utxo_data.map((m: any) => {
+            let utxo = new sdk.UnspentTxOutput();
+            utxo.fromJSON(m);
+            return utxo;
+        });
+
+        const tx = makeOriginalTransaction(key_pairs[0], sdk.JSBI.BigInt(52000), sdk.JSBI.BigInt(0.0001 * 10_000_000));
+        const canceller = new sdk.TxCanceller(tx, utxos, key_pairs);
+        const res = canceller.build();
+        assert.strictEqual(res.code, sdk.TxCancelResultCode.NotEnoughFee);
+        assert.ok(res.tx === undefined);
+    });
+
+    it ("Successful testing of cancellation transactions", () =>
+    {
+        let utxo_data = JSON.parse(JSON.stringify(utxo_array));
+        const utxos: Array<sdk.UnspentTxOutput> = utxo_data.map((m: any) => {
+            let utxo = new sdk.UnspentTxOutput();
+            utxo.fromJSON(m);
+            return utxo;
+        });
+
+        const tx = makeOriginalTransaction(key_pairs[0], sdk.JSBI.BigInt("20000000000000"), sdk.JSBI.BigInt("30000000000000"));
+        const canceller = new sdk.TxCanceller(tx, utxos, key_pairs);
+        const res = canceller.build();
+        assert.strictEqual(res.code, sdk.TxCancelResultCode.Success);
+        assert.ok(res.tx !== undefined);
+
+        let expected = {
+            "inputs": [
+                {
+                    "utxo": "0x6fbcdb2573e0f5120f21f1875b6dc281c2eca3646ec2c39d703623d89b0eb83cd4b12b73f18db6bc6e8cbcaeb100741f6384c498ff4e61dd189e728d80fb9673",
+                    "unlock": {
+                        "bytes": "yMh/dP7Vt0qjMCvG7Se/R2gIT6NGzMvPuXmL16h8zQZYDxvIDLC4FY6vrAybr+DQUtPPxmKwJ6J6ikL733dAYg=="
+                    },
+                    "unlock_age": 0
+                },
+                {
+                    "utxo": "0x75283072696d82d8bca2fe45471906a26df1dbe0736e41a9f78e02a14e2bfced6e0cb671f023626f890f28204556aca217f3023c891fe64b9f4b3450cb3e80ad",
+                    "unlock": {
+                        "bytes": "q0jWyJRzsrAIBUFQsPfmb5+xmtFPo87cQDFzlJNMQgRvF1uT54Dt9q5q2/d82g287/CdopNNST4MoXigVwaBMQ=="
+                    },
+                    "unlock_age": 0
+                }
+            ],
+            "outputs": [
+                {
+                    "type": 0,
+                    "value": "19999999940089",
+                    "lock": {
+                        "type": 0,
+                        "bytes": "uvf5H/3E3rpj8r12wjpHMPSOcoAhhCa2ecQMw6HCI84="
+                    }
+                },
+                {
+                    "type": 0,
+                    "value": "19999999940089",
+                    "lock": {
+                        "type": 0,
+                        "bytes": "8Pfbo1EB2MhMyXG64ZzvTt50VuOGRGwIDjiXoA5xyZ8="
+                    }
+                }
+            ],
+            "payload": "",
+            "lock_height": "0"
+        };
+
+        if (res.tx !== undefined)
+        {
+            let tx_size = tx.getNumberOfBytes()
+            let total_fee = sdk.JSBI.BigInt(sdk.Utils.FEE_FACTOR * tx_size);
+            let minimum = sdk.JSBI.BigInt(100_000);
+            if (sdk.JSBI.lessThan(total_fee, minimum))
+                total_fee = sdk.JSBI.BigInt(minimum);
+
+            let adjusted_fee = sdk.JSBI.divide(total_fee, sdk.JSBI.BigInt(tx_size));
+
+            let cancel_adjusted_fee = sdk.JSBI.divide(
+                sdk.JSBI.multiply(
+                    adjusted_fee,
+                    sdk.JSBI.add(
+                        sdk.JSBI.BigInt(100),
+                        sdk.JSBI.BigInt(sdk.TxCanceller.double_spent_threshold_pct)
+                    )
+                ),
+                sdk.JSBI.BigInt(100)
+            );
+
+            let cancel_tx_size = res.tx.getNumberOfBytes();
+            let cancel_total_fee = sdk.JSBI.multiply(cancel_adjusted_fee, sdk.JSBI.BigInt(cancel_tx_size));
+
+            let in_sum = utxos.reduce<sdk.JSBI>((sum, n) =>
+                sdk.JSBI.add(sum, n.amount), sdk.JSBI.BigInt(0));
+            let out_sum = res.tx.outputs.reduce<sdk.JSBI>((sum, n) =>
+                sdk.JSBI.add(sum, n.value), sdk.JSBI.BigInt(0));
+            assert.deepStrictEqual(sdk.JSBI.subtract(in_sum, out_sum), cancel_total_fee);
+
+            res.tx.inputs.forEach((value: sdk.TxInput, idx: number) => {
+                expected.inputs[idx].unlock = value.unlock.toJSON();
+            });
+            assert.deepStrictEqual(JSON.stringify(res.tx), JSON.stringify(expected));
+        }
+    });
+});


### PR DESCRIPTION
I implemented a function to cancel transactions that have already been sent.
In order for transactions already sent to be canceled, a new transaction must be created.
The new transaction uses the amount of UTXO used in the previous transaction and the public address as output.
However, the transaction fee should be set higher than the previous transaction.

It uses Agora's processing of double-spending transactions and Stoa's multi UTXO provision.