### PR TITLE
Replace with time stamp instead of block height in ProposalData

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@
 export { IBOASodium } from "boa-sodium-base-ts";
 export { Hash, hash, hashMulti, makeUTXOKey, hashFull, hashPart } from "./modules/common/Hash";
 export { Height } from "./modules/common/Height";
+export { TimeStamp } from "./modules/common/TimeStamp";
 export { KeyPair, PublicKey, SecretKey } from "./modules/common/KeyPair";
 export { Signature } from "./modules/common/Signature";
 export { Scalar, Point } from "./modules/common/ECC";

--- a/src/modules/common/TimeStamp.ts
+++ b/src/modules/common/TimeStamp.ts
@@ -1,0 +1,77 @@
+/*******************************************************************************
+
+    The class that defines the time stamp.
+
+    Copyright:
+        Copyright (c) 2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+import { SmartBuffer } from "smart-buffer";
+import { Utils } from "../utils/Utils";
+import { VarInt } from "../utils/VarInt";
+
+import JSBI from "jsbi";
+
+/**
+ * The class that defines the time stamp.
+ */
+export class TimeStamp {
+    /**
+     * The time stamp
+     */
+    public value: JSBI;
+
+    /**
+     * Construct
+     * @param value The time stamp
+     */
+    constructor(value: JSBI | string | number) {
+        this.value = JSBI.BigInt(value);
+    }
+
+    /**
+     * Collects data to create a hash.
+     * @param buffer The buffer where collected data is stored
+     */
+    public computeHash(buffer: SmartBuffer) {
+        const buf = Buffer.allocUnsafe(8);
+        Utils.writeJSBigIntLE(buf, this.value);
+        buffer.writeBuffer(buf);
+    }
+
+    /**
+     * Sets from the Date
+     * @param date The instance of Date
+     */
+    public static fromDateTime(date: Date): TimeStamp {
+        return new TimeStamp(JSBI.BigInt(date.getTime()));
+    }
+
+    /**
+     * Converts this object to its JSON representation
+     */
+    public toJSON(key?: string): number {
+        return JSBI.toNumber(this.value);
+    }
+
+    /**
+     * Serialize as binary data.
+     * @param buffer The buffer where serialized data is stored
+     */
+    public serialize(buffer: SmartBuffer) {
+        VarInt.fromJSBI(this.value, buffer);
+    }
+
+    /**
+     * Deserialize as binary data.
+     * @param buffer The buffer to be deserialized
+     */
+    public static deserialize(buffer: SmartBuffer): TimeStamp {
+        return new TimeStamp(VarInt.toJSBI(buffer));
+    }
+}

--- a/src/modules/vote/ProposalData.ts
+++ b/src/modules/vote/ProposalData.ts
@@ -12,6 +12,7 @@
 *******************************************************************************/
 
 import { Hash } from "../common/Hash";
+import { TimeStamp } from "../common/TimeStamp";
 import { PublicKey } from "../common/KeyPair";
 import { Utils } from "../utils/Utils";
 import { VarInt } from "../utils/VarInt";
@@ -55,14 +56,14 @@ export class ProposalData {
     public proposal_title: string;
 
     /**
-     * The block height of voting start
+     * The time of voting start
      */
-    public vote_start_height: JSBI;
+    public vote_start_time: TimeStamp;
 
     /**
-     * The block height of voting end
+     * The time of voting end
      */
-    public vote_end_height: JSBI;
+    public vote_end_time: TimeStamp;
 
     /**
      * The hash of the documentation
@@ -105,8 +106,8 @@ export class ProposalData {
      * @param proposal_type         The type of the proposal, 0: System, 1: Funding
      * @param proposal_id           The ID of the proposal
      * @param proposal_title        The title of the proposal
-     * @param vote_start_height     The block height of voting start
-     * @param vote_end_height       The block height of voting end
+     * @param vote_start_time       The time of voting start
+     * @param vote_end_time         The time of voting end
      * @param doc_hash              The hash of the documentation
      * @param fund_amount           The amount of the funding
      * @param proposal_fee          The proposal fee
@@ -120,8 +121,8 @@ export class ProposalData {
         proposal_type: ProposalType,
         proposal_id: string,
         proposal_title: string,
-        vote_start_height: JSBI,
-        vote_end_height: JSBI,
+        vote_start_time: TimeStamp,
+        vote_end_time: TimeStamp,
         doc_hash: Hash,
         fund_amount: JSBI,
         proposal_fee: JSBI,
@@ -134,8 +135,8 @@ export class ProposalData {
         this.proposal_type = proposal_type;
         this.proposal_id = proposal_id;
         this.proposal_title = proposal_title;
-        this.vote_start_height = vote_start_height;
-        this.vote_end_height = vote_end_height;
+        this.vote_start_time = vote_start_time;
+        this.vote_end_time = vote_end_time;
         this.doc_hash = doc_hash;
         this.fund_amount = fund_amount;
         this.proposal_fee = proposal_fee;
@@ -168,8 +169,8 @@ export class ProposalData {
         VarInt.fromNumber(temp.length, buffer);
         buffer.writeBuffer(temp);
 
-        VarInt.fromJSBI(this.vote_start_height, buffer);
-        VarInt.fromJSBI(this.vote_end_height, buffer);
+        this.vote_start_time.serialize(buffer);
+        this.vote_end_time.serialize(buffer);
 
         buffer.writeBuffer(this.doc_hash.data);
 
@@ -207,8 +208,8 @@ export class ProposalData {
         temp = Utils.readBuffer(buffer, length);
         let proposal_title = temp.toString();
 
-        let vote_start_height = VarInt.toJSBI(buffer);
-        let vote_end_height = VarInt.toJSBI(buffer);
+        let vote_start_time = TimeStamp.deserialize(buffer);
+        let vote_end_time = TimeStamp.deserialize(buffer);
 
         let doc_hash = new Hash(buffer.readBuffer(Hash.Width));
         let fund_amount = VarInt.toJSBI(buffer);
@@ -223,8 +224,8 @@ export class ProposalData {
             proposal_type,
             proposal_id,
             proposal_title,
-            vote_start_height,
-            vote_end_height,
+            vote_start_time,
+            vote_end_time,
             doc_hash,
             fund_amount,
             proposal_fee,

--- a/tests/Vote.test.ts
+++ b/tests/Vote.test.ts
@@ -38,8 +38,8 @@ describe("Vote Data", () => {
             sdk.ProposalType.Fund,
             "ID1234567890",
             "Title",
-            sdk.JSBI.BigInt(1000),
-            sdk.JSBI.BigInt(3026),
+            sdk.TimeStamp.fromDateTime(new Date(Date.UTC(2021, 10, 1))),
+            sdk.TimeStamp.fromDateTime(new Date(Date.UTC(2021, 10, 14))),
             new sdk.Hash(Buffer.alloc(sdk.Hash.Width)),
             sdk.JSBI.BigInt(10000000000000),
             sdk.JSBI.BigInt(100000000000),
@@ -200,8 +200,8 @@ describe("Vote Data", () => {
             sdk.ProposalType.Fund,
             "ID1234567890",
             "Title",
-            sdk.JSBI.BigInt(1000),
-            sdk.JSBI.BigInt(3026),
+            sdk.TimeStamp.fromDateTime(new Date(Date.UTC(2021, 10, 1))),
+            sdk.TimeStamp.fromDateTime(new Date(Date.UTC(2021, 10, 14))),
             new sdk.Hash(Buffer.alloc(sdk.Hash.Width)),
             sdk.JSBI.BigInt(10000000000000),
             sdk.JSBI.BigInt(100000000000),
@@ -235,7 +235,7 @@ describe("Vote Data", () => {
             ],
             voting_fee: "12000000",
             payload:
-                "CFBST1BPU0FMBlZvdGVyYQEMSUQxMjM0NTY3ODkwBVRpdGxl/egD/dILAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP8AoHJOGAkAAP8A6HZIFwAAAP7A/JsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN2tOi+MKGfTMi85pssUrbmVFl5Vu3UowAYGsEqeEt26xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM=",
+                "CFBST1BPU0FMBlZvdGVyYQEMSUQxMjM0NTY3ODkwBVRpdGxl/wCwy9h8AQAA/wBcvht9AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP8AoHJOGAkAAP8A6HZIFwAAAP7A/JsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN2tOi+MKGfTMi85pssUrbmVFl5Vu3UowAYGsEqeEt26xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM=",
         };
         assert.deepStrictEqual(link_data, expected);
     });

--- a/tests/Votera.test.ts
+++ b/tests/Votera.test.ts
@@ -218,7 +218,7 @@ export class TestStoa {
                             ),
                         ],
                         Buffer.from(
-                            "'CFBST1BPU0FMBlZvdGVyYQEMSUQxMjM0NTY3ODkwBVRpdGxl/egD/dILAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP8AoHJOGAkAAP8A6HZIFwAAAP7A/JsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN2tOi+MKGfTMi85pssUrbmVFl5Vu3UowAYGsEqeEt26xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM=",
+                            "CFBST1BPU0FMBlZvdGVyYQEMSUQxMjM0NTY3ODkwBVRpdGxl/wCwy9h8AQAA/wBcvht9AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP8AoHJOGAkAAP8A6HZIFwAAAP7A/JsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAN2tOi+MKGfTMi85pssUrbmVFl5Vu3UowAYGsEqeEt26xOYx2v6aWx69nACIFINcMrCytXJmcWy99/N+ZlGEIWM=",
                             "base64"
                         )
                     );
@@ -385,8 +385,8 @@ describe("Checking the proposal and ballot data", () => {
             proposal_type: sdk.ProposalType.Fund,
             proposal_id: "ID1234567890",
             proposal_title: "Title",
-            vote_start_height: sdk.JSBI.BigInt(1000),
-            vote_end_height: sdk.JSBI.BigInt(3026),
+            vote_start_time: sdk.TimeStamp.fromDateTime(new Date(Date.UTC(2021, 10, 1))),
+            vote_end_time: sdk.TimeStamp.fromDateTime(new Date(Date.UTC(2021, 10, 14))),
             doc_hash: new sdk.Hash(Buffer.alloc(sdk.Hash.Width)),
             fund_amount: sdk.JSBI.BigInt(10000000000000),
             proposal_fee: sdk.JSBI.BigInt(100000000000),
@@ -448,8 +448,8 @@ describe("Checking the proposal and ballot data", () => {
                         assert.deepStrictEqual(payload.proposal_type, expected_data.proposal_type);
                         assert.deepStrictEqual(payload.proposal_id, expected_data.proposal_id);
                         assert.deepStrictEqual(payload.proposal_title, expected_data.proposal_title);
-                        assert.deepStrictEqual(payload.vote_start_height, expected_data.vote_start_height);
-                        assert.deepStrictEqual(payload.vote_end_height, expected_data.vote_end_height);
+                        assert.deepStrictEqual(payload.vote_start_time, expected_data.vote_start_time);
+                        assert.deepStrictEqual(payload.vote_end_time, expected_data.vote_end_time);
                         assert.deepStrictEqual(payload.doc_hash, expected_data.doc_hash);
                         assert.deepStrictEqual(payload.fund_amount, expected_data.fund_amount);
                         assert.deepStrictEqual(payload.proposal_fee, expected_data.proposal_fee);


### PR DESCRIPTION
The voting period cannot be defined as the block height because blocks are not created when there is no transaction.
So change the voting period to timestamp.