### PR TITLE
Remove a function in BOAClient.getHeightAt()

### DIFF
--- a/src/modules/net/BOAClient.ts
+++ b/src/modules/net/BOAClient.ts
@@ -181,31 +181,6 @@ export class BOAClient {
     }
 
     /**
-     * Request the block height corresponding to to the block creation time
-     * @param when Unix epoch time
-     * @returns height If it already exists in the block,
-     * it returns the height of the block,
-     * if the block has not yet been created,
-     * it returns the estimated height is returned.
-     */
-    public getHeightAt(when: Date): Promise<number> {
-        return new Promise<number>((resolve, reject) => {
-            let time = Math.ceil(when.getTime() / 1000);
-            let url = uri(this.server_url).directory("block_height_at").filename(time.toString());
-
-            Request.get(url.toString())
-                .then((response: AxiosResponse) => {
-                    if (response.status == 200) resolve(Number(response.data));
-                    else reject(new Error("The date before Genesis Block creation is invalid."));
-                    reject(handleNetworkError({ response: response }));
-                })
-                .catch((reason: any) => {
-                    reject(handleNetworkError(reason));
-                });
-        });
-    }
-
-    /**
      * Saves the data to the blockchain
      * @param tx The instance of the Transaction
      * @returns Returns true if success, otherwise returns false

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -648,15 +648,6 @@ export class TestStoa {
             res.status(200).send(JSON.stringify(result));
         });
 
-        this.app.get("/block_height_at/:time", (req: express.Request, res: express.Response) => {
-            const time_stamp = Number(req.params.time);
-
-            const zero = 1609459200;
-            const height = Math.floor((time_stamp - zero) / (60 * 10));
-            if (height < 0) res.status(204).send("No Content");
-            else res.status(200).send(JSON.stringify(height.toString()));
-        });
-
         this.app.set("port", this.port);
 
         // Listen on provided this.port on this.address.
@@ -1000,36 +991,6 @@ describe("BOA Client", () => {
         assert.strictEqual(res.message, "The new pre-image height is not valid.");
 
         doneIt();
-    });
-
-    it("test for getHeightAt", async () => {
-        // Set URL
-        let stoa_uri = URI("http://localhost").port(stoa_port);
-        let agora_uri = URI("http://localhost").port(agora_port);
-
-        // Create BOA Client
-        let boa_client = new sdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
-        let date = new Date(Date.UTC(2021, 3, 29, 0, 0, 0));
-        let height = await boa_client.getHeightAt(date);
-        assert.strictEqual(height, 16992);
-
-        date = new Date(Date.UTC(2020, 11, 29, 0, 0, 0));
-        await assert.rejects(
-            boa_client.getHeightAt(date),
-            new Error("The date before Genesis Block creation is invalid.")
-        );
-
-        date = new Date(Date.UTC(2021, 0, 1, 0, 0, 0));
-        height = await boa_client.getHeightAt(date);
-        assert.strictEqual(height, 0);
-
-        date = new Date(Date.UTC(2021, 0, 1, 0, 9, 59));
-        height = await boa_client.getHeightAt(date);
-        assert.strictEqual(height, 0);
-
-        date = new Date(Date.UTC(2021, 0, 1, 0, 10, 0));
-        height = await boa_client.getHeightAt(date);
-        assert.strictEqual(height, 1);
     });
 
     it("Test client name and version", async () => {


### PR DESCRIPTION
Blocks are not created when there is no transaction, so it is impossible to provide the expected time for block creation.
Therefore, it removes the function that provides that function.