### PR TITLE
Upgrade to compute more than two buffers at `hashMulti`

### DIFF
--- a/src/modules/common/Hash.ts
+++ b/src/modules/common/Hash.ts
@@ -134,17 +134,13 @@ export function hash(source: Buffer): Hash {
 
 /**
  * Creates a hash of the two buffer combined.
- * @param source1 The original for creating hash
- * @param source2 The original for creating hash
+ * @param args The array of Buffer for creating hash
  * @returns The instance of Hash
  * See_Also https://github.com/bosagora/agora/blob/93c31daa616e76011deee68a8645e1b86624ce3d/source/agora/common/Hash.d#L239-L255
  */
-export function hashMulti(source1: Buffer, source2: Buffer): Hash {
-    let merge = Buffer.alloc(source1.length + source2.length);
-    source1.copy(merge);
-    source2.copy(merge, source1.length);
-
-    return new Hash(Buffer.from(SodiumHelper.sodium.crypto_generichash(Hash.Width, merge)));
+export function hashMulti(...args: Buffer[]): Hash {
+    let buffer = args.reduce<Buffer>((sum, elem) => Buffer.concat([sum, elem]), Buffer.alloc(0));
+    return new Hash(Buffer.from(SodiumHelper.sodium.crypto_generichash(Hash.Width, buffer)));
 }
 
 /**

--- a/tests/Hash.test.ts
+++ b/tests/Hash.test.ts
@@ -66,6 +66,15 @@ describe("Hash", () => {
             h.toString(),
             "0xe0343d063b14c52630563ec81b0f91a84ddb05f2cf05a2e4330ddc79bd3a06e57c2e756f276c112342ff1d6f1e74d05bdb9bf880abd74a2e512654e12d171a74"
         );
+
+        // Source 3 : "boa"
+        let boa = sdk.hash(Buffer.from("boa"));
+
+        let h2 = sdk.hash(Buffer.concat([foo.data, bar.data, boa.data]));
+        let h3 = sdk.hashMulti(foo.data, bar.data, boa.data);
+
+        // Check
+        assert.strictEqual(h3.toString(), h2.toString());
     });
 
     // The test codes below compare with the values calculated in Agora.


### PR DESCRIPTION
Currently, only two are supported. I modified it to allow for several.