### PR TITLE
Use a function Utils.readBuffer for deserializing in Signature

### DIFF
--- a/src/modules/common/Signature.ts
+++ b/src/modules/common/Signature.ts
@@ -108,6 +108,6 @@ export class Signature {
      * @param buffer - The buffer to be deserialized
      */
     public static deserialize(buffer: SmartBuffer): Signature {
-        return new Signature(buffer.readBuffer(Signature.Width));
+        return new Signature(Utils.readBuffer(buffer, Signature.Width));
     }
 }


### PR DESCRIPTION
It has the ability to check the size of the data left behind.