### PR TITLE
Fix the sort order of transaction inputs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "boa-sdk-ts",
-    "version": "0.0.54",
+    "version": "0.0.55",
     "description": "The TypeScript BOA SDK library",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/modules/data/TxInput.ts
+++ b/src/modules/data/TxInput.ts
@@ -112,7 +112,7 @@ export class TxInput {
      * The compare function of TxInput
      */
     public static compare(a: TxInput, b: TxInput): number {
-        return Buffer.compare(a.utxo.data, b.utxo.data);
+        return Utils.compareBuffer(a.utxo.data, b.utxo.data);
     }
 
     /**

--- a/src/modules/utils/TxBuilder.ts
+++ b/src/modules/utils/TxBuilder.ts
@@ -157,7 +157,8 @@ export class TxBuilder {
 
         let _unlocker = unlocker !== undefined ? unlocker : this.keyUnlocker;
         tx.inputs.forEach((value, idx) => {
-            value.unlock = _unlocker(tx, this.inputs[idx], idx);
+            let raw = this.inputs.find((m) => Buffer.compare(m.utxo.data, value.utxo.data) === 0);
+            if (raw !== undefined) value.unlock = _unlocker(tx, raw, idx);
         });
 
         this.payload = undefined;

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -1046,19 +1046,19 @@ describe("BOA Client", () => {
         let utxos = [
             {
                 utxo: new sdk.Hash(
-                    "0x81a326afa790003c32517a2a2556613004e6147edac28d576cf7bcc2daadf4bb60be1f644c229b775e7894844ec66b2d70ddf407b8196b46bc1dfe42061c7497"
+                    "0x4028965b7408566a66e4cf8c603a1cdebc7659a3e693d36d2fdcb39b196da967914f40ef4966d5b4b1f4b3aae00fbd68ffe8808b070464c2a101d44f4d7b0170"
                 ),
                 amount: sdk.JSBI.BigInt(100000),
             },
             {
                 utxo: new sdk.Hash(
-                    "0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a"
+                    "0x81a326afa790003c32517a2a2556613004e6147edac28d576cf7bcc2daadf4bb60be1f644c229b775e7894844ec66b2d70ddf407b8196b46bc1dfe42061c7497"
                 ),
                 amount: sdk.JSBI.BigInt(200000),
             },
             {
                 utxo: new sdk.Hash(
-                    "0x4028965b7408566a66e4cf8c603a1cdebc7659a3e693d36d2fdcb39b196da967914f40ef4966d5b4b1f4b3aae00fbd68ffe8808b070464c2a101d44f4d7b0170"
+                    "0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a"
                 ),
                 amount: sdk.JSBI.BigInt(300000),
             },
@@ -1496,63 +1496,48 @@ describe("BOA Client", () => {
         let expected = {
             inputs: [
                 {
-                    utxo: "0xc3780f9907a97c20a2955945544e7732a60702c32d81e016bdf1ea172b7b7fb96e9a4164176663a146615307aaadfbbad77e615a7c792a89191e85471120d314",
-                    unlock: {
-                        bytes: "Ho2Lxmx4UJpzcivLgZOTeOsbtFwQ2QzpKMHLY07raQrEbM57DEHaR5v8vDxxkyh1NZn02+CI3M8CGDLFa1EQEQ==",
-                    },
-                    unlock_age: 0,
-                },
-                {
                     utxo: "0x3451d94322524e3923fd26f0597fb8a9cdbf3a9427c38ed1ca61104796d39c5b9b5ea33d576f17c2dc17bebc5d84a0559de8c8c521dfe725d4c352255fc71e85",
                     unlock: {
-                        bytes: "XWndrI7QXgY1Tb3lrk4mpC2PJIvnHKv5pynXfla/JAADl6MnMAGMpRgtZeg/8Gmw9Wih0qgrbCBiTM+tUFCcdw==",
+                        bytes: "+yvJHCCjvKMLOMtqJsdyNMtxpBRI18eouEC6xBGNJwehEXfREFnpkUkRxJIfgypBo1b+ZR9uH6VeqCK298FT1g==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0x7e1958dbe6839d8520d65013bbc85d36d47a9f64cf608cc66c0d816f0b45f5c8a85a8990725ffbb1ab13c3c65b45fdc06f4745d455e00e1068c4c5c0b661d685",
                     unlock: {
-                        bytes: "PyQdYPHxgIaoGW3oSpknJSp/W9nEGuZIK7oL1o6b3QZZ2stIEoX/Q1aABZyKGAuX52Jj5pKU0/Jh8/pJ7o3jVA==",
+                        bytes: "Bofplo7Y8ThhlHR2DQpvVRIoDopgRXM0nLzL16pj+Qwl7JVcgZbtdRqmf2hLmJk0TBhpHG4irf5qN54XMuz3XQ==",
+                    },
+                    unlock_age: 0,
+                },
+                {
+                    utxo: "0xc3780f9907a97c20a2955945544e7732a60702c32d81e016bdf1ea172b7b7fb96e9a4164176663a146615307aaadfbbad77e615a7c792a89191e85471120d314",
+                    unlock: {
+                        bytes: "vGjgJWw6WzI+YFWTPPeXOZRM0F631K1/y7lODyYpRQzK5RXwDSGJ0bme9WWeDf9aSDqhyodvnjYUaJY8/MGP4w==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0xd44608de8a5015b04f933098fd7f67f84ffbf00c678836d38c661ab6dc1f149606bdc96bad149375e16dc5722b077b14c0a4afdbe6d30932f783650f435bcb92",
                     unlock: {
-                        bytes: "SMFTDslZxDiVsf/A82CXWpjN+dnEw0ITyBmLWtP8qgTJNEIk2S5SsLo3x+RGVBNajVnSiB7CQvIWtDGgGxTmYg==",
+                        bytes: "7f4NX9NPDhDRa+3KhEjyFgnRqjXXfk2KoHX4XlNAgwCLgahelWE8pvMksxisHlYafU+oxI60AkpwEjLZ7ff8/A==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0xfca92fe76629311c6208a49e89cb26f5260777278cd8b272e7bb3021adf429957fd6844eb3b8ff64a1f6074126163fd636877fa92a1f4329c5116873161fbaf8",
                     unlock: {
-                        bytes: "tnqSKuN/YfU1Fpm2QVZsqYv/+13e97w5l3mAvuTlFAioH34dQ6VMp7t9qTRNy2Tx7S4DQgRGkdByQ1n95D4wlg==",
+                        bytes: "t54M0O4k7hKMTYxK/oCpgpU56I5M+n6CLOoCxLFP9Qh/0SSE4HQo7ws6g6oXGQa+Vxij4bEH67RsUb0f4SvuYQ==",
                     },
                     unlock_age: 0,
                 },
             ],
             outputs: [
-                {
-                    type: 0,
-                    value: "146600",
-                    lock: {
-                        type: 0,
-                        bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=",
-                    },
-                },
-                {
-                    type: 0,
-                    value: "200000",
-                    lock: {
-                        type: 0,
-                        bytes: "x60Co13nUDL3h+pKXCsG460FHRgDZWnJFfTYnch/tLg=",
-                    },
-                },
+                { type: 0, value: "146600", lock: { type: 0, bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=" } },
+                { type: 0, value: "200000", lock: { type: 0, bytes: "x60Co13nUDL3h+pKXCsG460FHRgDZWnJFfTYnch/tLg=" } },
             ],
             payload: "YXRhZCBldG92",
             lock_height: "0",
         };
-
         // Because randomly generated values are used when signing,
         // different signatures are created even when signed using the same secret key.
         // Therefore, omit the signature comparison.

--- a/tests/TxBuilder.test.ts
+++ b/tests/TxBuilder.test.ts
@@ -79,16 +79,16 @@ describe("TxBuilder", () => {
         let expected = {
             inputs: [
                 {
-                    utxo: "0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32",
+                    utxo: "0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef",
                     unlock: {
-                        bytes: "J4kiUyFzQP+2jToI7OFJSmQzWkklCdB5OD4uqxPhjwl8SVN9XT6THqDk1Z2zEKFBuCWIKmQDMFsPCxrungvAfQ==",
+                        bytes: "Q/xkI//GMoaGCA98vNLjTwul7MpQAb86EiFlRwBMugKmHn8XyYkHE/XIS+A0lsefsoSv+Y5RGu2+LYI3oP+bNQ==",
                     },
                     unlock_age: 0,
                 },
                 {
-                    utxo: "0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef",
+                    utxo: "0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32",
                     unlock: {
-                        bytes: "SwwNLYNgDP+trbErXKIKNjVfv2QiBxg0s0cxocKWFg86fiVIbX+wElOuDHf5UzJ+JCob3Fr1JAGx6oRPdevBQA==",
+                        bytes: "YDT5tr6Ifu8slttlTQ1ORuchgkw1tGjn1PqqT/4/3gPK2Bovxm4gIWhmEnkDv+0JaMSf+cl5jZiwaNK2Wv4SvA==",
                     },
                     unlock_age: 0,
                 },
@@ -97,24 +97,17 @@ describe("TxBuilder", () => {
                 {
                     type: 0,
                     value: "1980000000",
-                    lock: {
-                        type: 0,
-                        bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=",
-                    },
+                    lock: { type: 0, bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=" },
                 },
                 {
                     type: 0,
                     value: "20000000",
-                    lock: {
-                        type: 0,
-                        bytes: "2uGT7+ya0+sVo6ohySeAdjX7lf+hSRNV7iLceOZXMN8=",
-                    },
+                    lock: { type: 0, bytes: "2uGT7+ya0+sVo6ohySeAdjX7lf+hSRNV7iLceOZXMN8=" },
                 },
             ],
             payload: "",
             lock_height: "0",
         };
-
         // Because randomly generated values are used when signing,
         // different signatures are created even when signed using the same secret key.
         // Therefore, omit the signature comparison.
@@ -145,16 +138,16 @@ describe("TxBuilder", () => {
         let expected = {
             inputs: [
                 {
-                    utxo: "0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32",
+                    utxo: "0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef",
                     unlock: {
-                        bytes: "K5ZN24UQeR5vJcMDzOg9ODHiDvMHAbC9zhW2w3ugNgvZw/tU7vm3Ww9enFwHwC2B/Vnq5qK9YKhRjnNleMmOqQ==",
+                        bytes: "pIiLEwhXC59GIZL6Xw9IP2g5wu3HES+Md1Wm45F5nA64oVpt5L/1Yf+0Myd2uNQWyzUUacn8+1RIslXwlcSh/w==",
                     },
                     unlock_age: 0,
                 },
                 {
-                    utxo: "0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef",
+                    utxo: "0xd9482016835acc6defdfd060216a5890e00cf8f0a79ab0b83d3385fc723cd45bfea66eb3587a684518ff1756951d38bf4f07abda96dcdea1c160a4f83e377c32",
                     unlock: {
-                        bytes: "FZYYYwBu5U8JnBX7UUOTn1viN1sdzL5c/NoLxXVJsg7lvOY/4XaAe2zffF4Tb2PNi1RjBPVnmdY95sw5yoeiBQ==",
+                        bytes: "+JGa7Yhyat4L/91kfriWiTtfxvgzQ1mbHIzcL5JVGQgG7yiORpb5+HCC6IYf9sqGOhjyjOKrfgZMssDnYGAmuA==",
                     },
                     unlock_age: 0,
                 },
@@ -163,16 +156,12 @@ describe("TxBuilder", () => {
                 {
                     type: 0,
                     value: "1999500000",
-                    lock: {
-                        type: 0,
-                        bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=",
-                    },
+                    lock: { type: 0, bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=" },
                 },
             ],
             payload: "YXRhZCBldG92",
             lock_height: "0",
         };
-
         // Because randomly generated values are used when signing,
         // different signatures are created even when signed using the same secret key.
         // Therefore, omit the signature comparison.


### PR DESCRIPTION
UTXO's hash is Little Endian, so we have to start from the back when comparing this. I fix the bug that is supposed to be compared from the beginning.
