### PR TITLE
Add the ability to request UTXO only for the amount required by Stoa

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export { Utils, Endian, ArrayRange, iota } from "./modules/utils/Utils";
 export { SodiumHelper } from "./modules/utils/SodiumHelper";
 export { checksum, validate } from "./modules/utils/CRC16";
 export { TxPayloadFee } from "./modules/utils/TxPayloadFee";
-export { UTXOManager } from "./modules/utils/UTXOManager";
+export { UTXOManager, UTXOProvider } from "./modules/utils/UTXOManager";
 export { TxBuilder, RawInput } from "./modules/utils/TxBuilder";
 export { TxCanceller, TxCancelResultCode, ITxCancelResult } from "./modules/utils/TxCanceller";
 export { VarInt } from "./modules/utils/VarInt";

--- a/src/modules/utils/UTXOManager.ts
+++ b/src/modules/utils/UTXOManager.ts
@@ -19,6 +19,8 @@
 import { UnspentTxOutput } from "../net/response/UnspentTxOutput";
 import { OutputType } from "../data/TxOutput";
 import { Hash } from "../common/Hash";
+import { PublicKey } from "../common/KeyPair";
+import { BOAClient } from "../net/BOAClient";
 import { Utils } from "./Utils";
 
 import JSBI from "jsbi";
@@ -154,6 +156,122 @@ export class UTXOManager {
      */
     public clear() {
         this.items.length = 0;
+    }
+}
+
+/**
+ * Class for managing UTXO
+ * Manage what is used and not used in payment for UTXO
+ */
+export class UTXOProvider {
+    /**
+     * Internal UTXO Array
+     */
+    private readonly items: Array<InternalUTXO>;
+
+    /**
+     * UTXO Owner's Public Key
+     * @private
+     */
+    private address: PublicKey;
+
+    /**
+     * It is a client to access Agora and Stoa.
+     * @private
+     */
+    private client: BOAClient;
+
+    /**
+     * Constructor
+     * @param address The instance of the PublicKey
+     * @param client  The instance of the BOAClient
+     */
+    constructor(address: PublicKey, client: BOAClient) {
+        this.address = address;
+        this.items = [];
+        this.client = client;
+    }
+
+    /**
+     * Add UTXOs. If it already exists, ignore it.
+     * After add, Two fields are used for sorting.
+     * One is unlock_height and the other is amount.
+     * The array is sorted in ascending order of unlock_height,
+     * and in ascending order of amount when the same unlock_height is.
+     * This allows a UTXO that is created first to be used first.
+     * It also allows small amounts to be used first.
+     * @param data The array of `UnspentTxOutput`
+     */
+    public add(data: Array<UnspentTxOutput>) {
+        let old_length = this.items.length;
+        this.items.push(
+            ...data
+                .filter((n) => this.items.find((m) => m.utxo.data.compare(n.utxo.data) === 0) === undefined)
+                .map((n) => new InternalUTXO(n.utxo, n.type, n.unlock_height, n.amount, n.height))
+        );
+
+        if (this.items.length > old_length)
+            this.items.sort((a, b) => {
+                let cmp = (a: JSBI, b: JSBI) => (JSBI.greaterThan(a, b) ? 1 : JSBI.lessThan(a, b) ? -1 : 0);
+                if (JSBI.notEqual(a.height, b.height)) return cmp(a.height, b.height);
+                return Utils.compareBuffer(a.utxo.data, b.utxo.data);
+            });
+    }
+
+    /**
+     * Returns an array of UTXOs to be used for input of transactions
+     * based on the amount entered.
+     * @param amount The required amount
+     * @param estimated_input_fee The estimated fee of the size of one TxInput
+     * @returns Returns the available array of UTXO. If the available amount
+     * is less than the requested amount, the empty array is returned.
+     */
+    public async getUTXO(amount: JSBI, estimated_input_fee: JSBI = JSBI.BigInt(0)): Promise<Array<UnspentTxOutput>> {
+        if (JSBI.lessThanOrEqual(amount, JSBI.BigInt(0)))
+            throw new Error(`Positive amount expected, not ${amount.toString()}`);
+
+        let target_amount: JSBI;
+        let result: UnspentTxOutput[] = [];
+
+        target_amount = JSBI.BigInt(amount);
+        while (true) {
+            target_amount = JSBI.add(target_amount, estimated_input_fee);
+            let sum = JSBI.BigInt(0);
+            let utxo = this.items
+                .filter((n) => !n.used)
+                .filter((n) => {
+                    if (JSBI.greaterThanOrEqual(sum, target_amount)) return false;
+                    sum = JSBI.add(sum, n.amount);
+                    n.used = true;
+
+                    target_amount = JSBI.add(target_amount, estimated_input_fee);
+                    return true;
+                })
+                .map((n) => new UnspentTxOutput(n.utxo, n.type, n.unlock_height, n.amount, n.height));
+            result.push(...utxo);
+            let res_sum = result.reduce<JSBI>((sum, value) => JSBI.add(sum, value.amount), JSBI.BigInt(0));
+            let estimated_amount = JSBI.add(amount, JSBI.multiply(estimated_input_fee, JSBI.BigInt(result.length)));
+            if (JSBI.greaterThanOrEqual(res_sum, estimated_amount)) break;
+
+            target_amount = JSBI.subtract(estimated_amount, res_sum);
+            let additional = await this.client.getWalletUTXOs(this.address, target_amount, 0, this.getLastUTXO());
+            // Not Enough Amount
+            if (additional.length == 0) {
+                this.items.forEach((m) => {
+                    if (result.find((n) => m.utxo.data.compare(n.utxo.data) !== undefined)) {
+                        m.used = false;
+                    }
+                });
+                result.length = 0;
+                break;
+            }
+            this.add(additional);
+        }
+        return result;
+    }
+
+    private getLastUTXO(): Hash | undefined {
+        return this.items.length === 0 ? undefined : this.items[this.items.length - 1].utxo;
     }
 }
 

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -1792,4 +1792,31 @@ describe("BOA Client", () => {
         assert.deepStrictEqual(third_utxos.length, 1);
         assert.deepStrictEqual(third_utxos[0].utxo.toString(), sample_utxo[0].utxo);
     });
+
+    it("Test the UTXOProvider", async () => {
+        // Set URL
+        let stoa_uri = URI("http://localhost").port(stoa_port);
+        let agora_uri = URI("http://localhost").port(agora_port);
+
+        // Create BOA Client
+        let boa_client = new sdk.BOAClient(stoa_uri.toString(), agora_uri.toString());
+
+        // Query
+        let public_key = new sdk.PublicKey("boa1xrq66nug6wnen9sp5cm7xhfw03yea8e9x63ggay3v5dhe6d9jerqz50eld0");
+
+        let utxoProvider = new sdk.UTXOProvider(public_key, boa_client);
+        // Request First UTXO
+        let first_utxos = await utxoProvider.getUTXO(sdk.JSBI.BigInt(300000), sdk.JSBI.BigInt(100000));
+        assert.deepStrictEqual(first_utxos.length, 3);
+        assert.deepStrictEqual(first_utxos[0].utxo.toString(), sample_utxo[1].utxo);
+        assert.deepStrictEqual(first_utxos[1].utxo.toString(), sample_utxo[2].utxo);
+        assert.deepStrictEqual(first_utxos[2].utxo.toString(), sample_utxo[3].utxo);
+
+        // Request Second UTXO
+        let second_utxos = await utxoProvider.getUTXO(sdk.JSBI.BigInt(300000), sdk.JSBI.BigInt(100000));
+        assert.deepStrictEqual(second_utxos.length, 3);
+        assert.deepStrictEqual(second_utxos[0].utxo.toString(), sample_utxo[4].utxo);
+        assert.deepStrictEqual(second_utxos[1].utxo.toString(), sample_utxo[5].utxo);
+        assert.deepStrictEqual(second_utxos[2].utxo.toString(), sample_utxo[6].utxo);
+    });
 });

--- a/tests/BOAClient.test.ts
+++ b/tests/BOAClient.test.ts
@@ -1229,39 +1229,31 @@ describe("BOA Client", () => {
                 {
                     utxo: "0x3451d94322524e3923fd26f0597fb8a9cdbf3a9427c38ed1ca61104796d39c5b9b5ea33d576f17c2dc17bebc5d84a0559de8c8c521dfe725d4c352255fc71e85",
                     unlock: {
-                        bytes: "xMEI8EVV9ifPBo3Cagv/ccXmeGOJOUz0vlhg+X6JMQnjMOKPxahrSRs0Ev6T6mO+G3MUho5/UWD1tQHjPArChQ==",
+                        bytes: "Vh6I8RKAw+8lM0NulP9PotF9DS/+o6cKAPfVNVaZ6QHKg3gM7IOVo3JG5fxw8b1YledAEKqBD/jhQzFVg0LI5w==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0x7e1958dbe6839d8520d65013bbc85d36d47a9f64cf608cc66c0d816f0b45f5c8a85a8990725ffbb1ab13c3c65b45fdc06f4745d455e00e1068c4c5c0b661d685",
                     unlock: {
-                        bytes: "Sw0lTFbfvJ9e0qizvOkKTiOeEE7RJne7Xeaflrn4BgqS4Iw31M7w4dHUtOwyL741WTjZ1M1AlVu6r2I3FZI64g==",
+                        bytes: "PlOoZA14zITTLDEc7rXmAN7mujRMRYl0y6B0bz3cew+sh0mAT5q0RJBmfRFdyWBjKUaDD1364pHdIaF79Pyhqg==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0xfca92fe76629311c6208a49e89cb26f5260777278cd8b272e7bb3021adf429957fd6844eb3b8ff64a1f6074126163fd636877fa92a1f4329c5116873161fbaf8",
                     unlock: {
-                        bytes: "BVD/9FzrMMFoChXNHsX3WPVQ+/3cIgGro2lpFvOeKQb62XlJGyApLXhjARIy/sAZ6ohvJKZZIxLPWs3H0eYgfA==",
+                        bytes: "wu4d7hTwbWTl8i6DHLxLN6ApLZwznOo/1eCowQlI9wzdTHaicUucykDomWv6E8aa31bgawJbGs5kkqKK3zMloA==",
                     },
                     unlock_age: 0,
                 },
             ],
             outputs: [
-                {
-                    type: 0,
-                    value: "100000",
-                    lock: {
-                        type: 0,
-                        bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=",
-                    },
-                },
+                { type: 0, value: "100000", lock: { type: 0, bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=" } },
             ],
             payload: "YXRhZCBldG92",
             lock_height: "0",
         };
-
         let tx = builder.assignPayload(vote_data).sign(sdk.OutputType.Payment, tx_fee, payload_fee);
 
         // Because randomly generated values are used when signing,
@@ -1346,32 +1338,24 @@ describe("BOA Client", () => {
                 {
                     utxo: "0x3451d94322524e3923fd26f0597fb8a9cdbf3a9427c38ed1ca61104796d39c5b9b5ea33d576f17c2dc17bebc5d84a0559de8c8c521dfe725d4c352255fc71e85",
                     unlock: {
-                        bytes: "ZFYeW86bZ06qFwu+F6Bjegi/ZZElrwEpvlw3IkM5KyqlHzUbCx3kOXfSSo8+WUtAFbKBtzES9QxU+ywfx6RUBQ==",
+                        bytes: "EEAMWbm0H0MkmB+FwbP1IvUmvPV1GR5THFECDg5C2APUfF9/SDEstKEmZWS2zJfh4PFXAzmpsiNrSOyuM2y6gw==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0xfca92fe76629311c6208a49e89cb26f5260777278cd8b272e7bb3021adf429957fd6844eb3b8ff64a1f6074126163fd636877fa92a1f4329c5116873161fbaf8",
                     unlock: {
-                        bytes: "ZFYeW86bZ06qFwu+F6Bjegi/ZZElrwEpvlw3IkM5KyqlHzUbCx3kOXfSSo8+WUtAFbKBtzES9QxU+ywfx6RUBQ==",
+                        bytes: "7pgvYc4SRBFAvPfD6Y9Ee+juGEvl9aXt7+UlkO2iWQfpYLL9HNZCH5PwslrCv3MvLpZH6H+kUYTozwSl2hg4lg==",
                     },
                     unlock_age: 0,
                 },
             ],
             outputs: [
-                {
-                    type: 0,
-                    value: "200000",
-                    lock: {
-                        type: 0,
-                        bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=",
-                    },
-                },
+                { type: 0, value: "200000", lock: { type: 0, bytes: "wa1PiNOnmZYBpjfjXS58SZ6fJTaihHSRZRt86aWWRgE=" } },
             ],
             payload: "YXRhZCBldG92",
             lock_height: "0",
         };
-
         // Because randomly generated values are used when signing,
         // different signatures are created even when signed using the same secret key.
         // Therefore, omit the signature comparison.
@@ -1518,35 +1502,35 @@ describe("BOA Client", () => {
                 {
                     utxo: "0x3451d94322524e3923fd26f0597fb8a9cdbf3a9427c38ed1ca61104796d39c5b9b5ea33d576f17c2dc17bebc5d84a0559de8c8c521dfe725d4c352255fc71e85",
                     unlock: {
-                        bytes: "+yvJHCCjvKMLOMtqJsdyNMtxpBRI18eouEC6xBGNJwehEXfREFnpkUkRxJIfgypBo1b+ZR9uH6VeqCK298FT1g==",
+                        bytes: "2Nk4xrLs6bFv3wZsWOwfnR7x3XjpNKt6hJFZ8BL8lAUANZmn82CcvuMRp5NPhn8GbiMr829GXq8xGT5BMGLHVQ==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0x7e1958dbe6839d8520d65013bbc85d36d47a9f64cf608cc66c0d816f0b45f5c8a85a8990725ffbb1ab13c3c65b45fdc06f4745d455e00e1068c4c5c0b661d685",
                     unlock: {
-                        bytes: "Bofplo7Y8ThhlHR2DQpvVRIoDopgRXM0nLzL16pj+Qwl7JVcgZbtdRqmf2hLmJk0TBhpHG4irf5qN54XMuz3XQ==",
+                        bytes: "xJfoZhmyJsJUOQOjy56eVCU2XwBMGXVCRN22oUuQ7QO2+DrpPCSSZ6Lqdiciaof67f4NYO72kMyfpJOPWV14ug==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0xc3780f9907a97c20a2955945544e7732a60702c32d81e016bdf1ea172b7b7fb96e9a4164176663a146615307aaadfbbad77e615a7c792a89191e85471120d314",
                     unlock: {
-                        bytes: "vGjgJWw6WzI+YFWTPPeXOZRM0F631K1/y7lODyYpRQzK5RXwDSGJ0bme9WWeDf9aSDqhyodvnjYUaJY8/MGP4w==",
+                        bytes: "j5tkee+U5JmM0xG75ReWy35X1UB8VHIG0ecraq7iVAgKi6QeO/x73wwUPQuSqk+0fLK7UhQqbIz985a7zIsJXw==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0xd44608de8a5015b04f933098fd7f67f84ffbf00c678836d38c661ab6dc1f149606bdc96bad149375e16dc5722b077b14c0a4afdbe6d30932f783650f435bcb92",
                     unlock: {
-                        bytes: "7f4NX9NPDhDRa+3KhEjyFgnRqjXXfk2KoHX4XlNAgwCLgahelWE8pvMksxisHlYafU+oxI60AkpwEjLZ7ff8/A==",
+                        bytes: "a9URqfrFPncsPEgcUkSOFHLvU/2StjBOkGhvXQuKFwX2j9QelzGiIkdx0snJ7HcT3XZDh1PrUKEZ/4jDzEOyuA==",
                     },
                     unlock_age: 0,
                 },
                 {
                     utxo: "0xfca92fe76629311c6208a49e89cb26f5260777278cd8b272e7bb3021adf429957fd6844eb3b8ff64a1f6074126163fd636877fa92a1f4329c5116873161fbaf8",
                     unlock: {
-                        bytes: "t54M0O4k7hKMTYxK/oCpgpU56I5M+n6CLOoCxLFP9Qh/0SSE4HQo7ws6g6oXGQa+Vxij4bEH67RsUb0f4SvuYQ==",
+                        bytes: "0iAH/LNVmuqGQDnLm3of43VjILzX9eqw5KqFutVVkgQ3nR8KGVyW6zeqlMTfow1TUOHoOo3zY5K+Afs83V01mA==",
                     },
                     unlock_age: 0,
                 },

--- a/tests/UTXOManager.test.ts
+++ b/tests/UTXOManager.test.ts
@@ -33,7 +33,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Freeze,
                 sdk.JSBI.BigInt(1),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(0)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -41,7 +42,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(2),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(1)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -49,7 +51,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(3),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(2)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -57,7 +60,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(4),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(3)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -65,7 +69,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(5),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(4)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -73,7 +78,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(6),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(5)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -81,7 +87,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(7),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(6)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -89,7 +96,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(8),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(7)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -97,7 +105,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Payment,
                 sdk.JSBI.BigInt(9),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(8)
             ),
             new sdk.UnspentTxOutput(
                 new sdk.Hash(
@@ -105,7 +114,8 @@ describe("Test for UTXOManager", () => {
                 ),
                 sdk.OutputType.Coinbase,
                 sdk.JSBI.BigInt(10),
-                sdk.JSBI.BigInt(10)
+                sdk.JSBI.BigInt(10),
+                sdk.JSBI.BigInt(9)
             ),
         ];
         manager = new sdk.UTXOManager(utxos);


### PR DESCRIPTION
Currently, SDK requests all UTXO and then extracts the UTXO required.
I changed it like this.
SDK requests Stoa for UTXO with the required amount for a specific address.
Stoa extracts UTXO that meets the conditions and provides it to SDK.

Relates to https://github.com/bosagora/boa-sdk-ts/issues/198