### PR TITLE
Reduce duplicate code in computeHash

### DIFF
--- a/src/modules/common/Height.ts
+++ b/src/modules/common/Height.ts
@@ -11,11 +11,12 @@
 
 *******************************************************************************/
 
+import { hashPart } from "./Hash";
 import { SmartBuffer } from "smart-buffer";
-import { Utils } from "../utils/Utils";
 import { VarInt } from "../utils/VarInt";
 
 import JSBI from "jsbi";
+
 /**
  * The class that defines the Height.
  */
@@ -38,9 +39,7 @@ export class Height {
      * @param buffer The buffer where collected data is stored
      */
     public computeHash(buffer: SmartBuffer) {
-        const buf = Buffer.allocUnsafe(8);
-        Utils.writeJSBigIntLE(buf, this.value);
-        buffer.writeBuffer(buf);
+        hashPart(this.value, buffer);
     }
 
     /**

--- a/src/modules/data/BitMask.ts
+++ b/src/modules/data/BitMask.ts
@@ -13,7 +13,7 @@
 
 import { SmartBuffer } from "smart-buffer";
 import { VarInt } from "../utils/VarInt";
-import { iota } from "../utils/Utils";
+import { iota, Utils } from "../utils/Utils";
 
 /**
  * The class that defines the BitMask
@@ -151,7 +151,7 @@ export class BitMask {
      */
     public static deserialize(buffer: SmartBuffer): BitMask {
         const length = VarInt.toNumber(buffer);
-        const bytes = buffer.readBuffer(VarInt.toNumber(buffer));
+        const bytes = Utils.readBuffer(buffer, VarInt.toNumber(buffer));
 
         return new BitMask(length, bytes);
     }

--- a/src/modules/data/BlockHeader.ts
+++ b/src/modules/data/BlockHeader.ts
@@ -14,7 +14,7 @@
 import { BitMask } from "./BitMask";
 import { Enrollment } from "./Enrollment";
 import { JSONValidator } from "../utils/JSONValidator";
-import { Hash } from "../common/Hash";
+import { Hash, hashPart } from "../common/Hash";
 import { Height } from "../common/Height";
 import { Signature } from "../common/Signature";
 import { Utils, iota } from "../utils/Utils";
@@ -147,9 +147,7 @@ export class BlockHeader {
         for (let elem of this.enrollments) elem.computeHash(buffer);
         this.random_seed.computeHash(buffer);
         for (let elem of this.missing_validators) buffer.writeUInt32LE(elem);
-        const buf = Buffer.allocUnsafe(8);
-        Utils.writeJSBigIntLE(buf, JSBI.BigInt(this.time_offset));
-        buffer.writeBuffer(buf);
+        hashPart(JSBI.BigInt(this.time_offset), buffer);
     }
 
     /**

--- a/src/modules/data/Enrollment.ts
+++ b/src/modules/data/Enrollment.ts
@@ -12,7 +12,7 @@
 *******************************************************************************/
 
 import { JSONValidator } from "../utils/JSONValidator";
-import { Hash } from "../common/Hash";
+import { Hash, hashPart } from "../common/Hash";
 import { Signature } from "../common/Signature";
 import { Sig } from "../common/Schnorr";
 import { VarInt } from "../utils/VarInt";
@@ -89,7 +89,7 @@ export class Enrollment {
     public computeHash(buffer: SmartBuffer) {
         this.utxo_key.computeHash(buffer);
         this.commitment.computeHash(buffer);
-        buffer.writeUInt32LE(this.cycle_length);
+        hashPart(this.cycle_length, buffer);
     }
 
     /**

--- a/src/modules/data/Transaction.ts
+++ b/src/modules/data/Transaction.ts
@@ -102,7 +102,7 @@ export class Transaction {
         hashPart(this.inputs, buffer);
         hashPart(this.outputs, buffer);
         hashPart(this.payload, buffer);
-        this.lock_height.computeHash(buffer);
+        hashPart(this.lock_height, buffer);
     }
 
     /**

--- a/src/modules/data/TxInput.ts
+++ b/src/modules/data/TxInput.ts
@@ -12,7 +12,7 @@
 *******************************************************************************/
 
 import { JSONValidator } from "../utils/JSONValidator";
-import { Hash, makeUTXOKey } from "../common/Hash";
+import { Hash, hashPart, makeUTXOKey } from "../common/Hash";
 import { Signature } from "../common/Signature";
 import { Unlock } from "../script/Lock";
 import { Utils } from "../utils/Utils";
@@ -87,7 +87,7 @@ export class TxInput {
      */
     public computeHash(buffer: SmartBuffer) {
         this.utxo.computeHash(buffer);
-        buffer.writeUInt32LE(this.unlock_age);
+        hashPart(this.unlock_age, buffer);
     }
 
     /**

--- a/src/modules/data/TxOutput.ts
+++ b/src/modules/data/TxOutput.ts
@@ -11,6 +11,7 @@
 
 *******************************************************************************/
 
+import { hashPart } from "../common/Hash";
 import { JSONValidator } from "../utils/JSONValidator";
 import { PublicKey } from "../common/KeyPair";
 import { Utils } from "../utils/Utils";
@@ -88,12 +89,8 @@ export class TxOutput {
      */
     public computeHash(buffer: SmartBuffer) {
         buffer.writeUInt32LE(this.type);
-
         this.lock.computeHash(buffer);
-
-        const buf = Buffer.allocUnsafe(8);
-        Utils.writeJSBigIntLE(buf, this.value);
-        buffer.writeBuffer(buf);
+        hashPart(this.value, buffer);
     }
 
     /**


### PR DESCRIPTION
I reduced duplicate code in computeHash.
I changed to stable Utils.readBuffer().
Function Utils.readBuffer() creates an exception when the end is reached while reading from the buffer.