### PR TITLE
Wallet: Add exception handling to the part where the transaction is built

### DIFF
--- a/tests/Wallet.test.ts
+++ b/tests/Wallet.test.ts
@@ -190,6 +190,23 @@ describe("Wallet", () => {
         assert.ok(res.data === undefined);
     });
 
+    it("Test the Wallet - transfer - Fail not exists any receiver", async () => {
+        const keypair = sdk.KeyPair.fromSeed(
+            new sdk.SecretKey("SAFRBTFVAB37EEJDIUGCDK5R3KSL3QDBO3SPS6GX752IILWB4NGQY7KJ")
+        );
+
+        const wallet = new sdk.Wallet(keypair, {
+            agoraEndpoint: "http://localhost:6000",
+            stoaEndpoint: "http://localhost:7000",
+            fee: sdk.WalletFeeOption.Medium,
+        });
+
+        const res = await wallet.transfer([]);
+
+        assert.deepStrictEqual(res.code, sdk.WalletResultCode.NotExistReceiver);
+        assert.ok(res.data === undefined);
+    });
+
     it("Test the Wallet - cancel", async () => {
         const keypair = sdk.KeyPair.fromSeed(
             new sdk.SecretKey("SAFRBTFVAB37EEJDIUGCDK5R3KSL3QDBO3SPS6GX752IILWB4NGQY7KJ")


### PR DESCRIPTION
I processed the transaction to return the reason and code if an error occurred during the creation of the transaction.