### PR TITLE
Change to consider freezing fees when canceling a transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boa-sdk-ts",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "boa-sdk-ts",
-    "version": "0.2.25",
+    "version": "0.2.26",
     "description": "The TypeScript BOA SDK library",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
When canceling a transaction, the fee is set 20% higher than that of the previous transaction. At this time, I modified the code to exclude freezing fees.